### PR TITLE
Add environment.impermanence

### DIFF
--- a/impermanence.nix
+++ b/impermanence.nix
@@ -1,0 +1,116 @@
+{ pkgs, config, lib, ... }:
+let
+  cfg = config.environment.impermanence;
+
+  persistentStoragePaths = lib.attrNames cfg;
+in
+{
+  options.environment.impermanence = lib.mkOption {
+    default = { };
+    type = with lib.types; attrsOf (
+      submodule {
+        options = {
+          files = lib.mkOption {
+            type = with lib.types; listOf str;
+            default = [ ];
+            description = "Files to bind mount to persistent storage.";
+          };
+
+          directories = lib.mkOption {
+            type = with lib.types; listOf str;
+            default = [ ];
+            description = "Directories to bind mount to persistent storage.";
+          };
+        };
+      }
+    );
+  };
+
+  config = {
+    fileSystems =
+      let
+        # Function to create fileSystem bind mount entries
+        mkBindMountNameValuePair = persistentStoragePath: path: {
+          name = "${path}";
+          value = {
+            device = "${persistentStoragePath}${path}";
+            options = [ "bind" ];
+          };
+        };
+
+        # Function to build the bind mounts for files and directories
+        mkBindMounts = persistentStoragePath:
+          lib.listToAttrs (map
+            (mkBindMountNameValuePair persistentStoragePath)
+            (cfg.${persistentStoragePath}.files ++
+              cfg.${persistentStoragePath}.directories)
+          );
+      in
+      lib.foldl' lib.recursiveUpdate { } (map mkBindMounts persistentStoragePaths);
+
+    system.activationScripts =
+      let
+        # Function to create a directory in both the place where we want
+        # to bind mount it as well as making sure it exists in the location
+        # where persistence is located.
+        mkDirCreationSnippet = persistentStoragePath: dir:
+          ''
+            mkdir -p "${dir}" "${persistentStoragePath}${dir}"
+          '';
+
+        # Function to create a file in both the place where we want to bind
+        # mount it as well as making sure it exists in the location where
+        # persistence is located.
+        mkFileCreationSnippet = persistentStoragePath: file:
+          let
+            targetFile = "${persistentStoragePath}${file}";
+          in
+          ''
+            mkdir -p $(dirname "${file}") $(dirname "${targetFile}") &&
+              touch "${file}" "${targetFile}"
+          '';
+
+        # Function to build the activation script string for creating files
+        # and directories as part of the activation script.
+        mkFileActivationScripts = persistentStoragePath:
+          lib.nameValuePair
+            "createFilesAndDirsIn-${lib.replaceStrings [ "/" "." " " ] [ "-" "-" "-" ] persistentStoragePath}"
+            (lib.noDepEntry (lib.concatStrings [
+              # Create activation scripts for files
+              (lib.concatMapStrings
+                (mkFileCreationSnippet persistentStoragePath)
+                cfg.${persistentStoragePath}.files
+              )
+
+              # Create activation scripts for directories
+              (lib.concatMapStrings
+                (mkDirCreationSnippet persistentStoragePath)
+                cfg.${persistentStoragePath}.directories
+              )
+            ]));
+
+      in
+      lib.listToAttrs (map mkFileActivationScripts persistentStoragePaths);
+
+    # Assert that all filesystems that we used are marked with neededForBoot.
+    assertions =
+      let
+        assertTest = cond: fs: (config.fileSystems.${fs}.neededForBoot == cond);
+      in
+      [{
+        assertion = lib.all (assertTest true) persistentStoragePaths;
+        message =
+          let
+            offenders = lib.filter (assertTest false) persistentStoragePaths;
+          in
+          ''
+            environment.impermanence:
+              All filesystems used to back must have the flag neededForBoot
+              set to true.
+
+            Please fix / remove the following paths:
+              ${lib.concatStringsSep "\n      " offenders}
+          '';
+      }];
+  };
+}


### PR DESCRIPTION
This new module have the same usage as the NixOS module but it touches
files and create directories where needed and then use bind mounts
instead of symlinks to access the files.

This is a first step to matching the ideas in #1, but I would like to have the users bit as well further on.

But I still this stand alone can be worth it to begin with if you want to have bind mounts instead.

My local usage:
```nix
{
  environment.impermanence."/persistent" = {
    directories = [
      "/etc/nixos"
      "/etc/NetworkManager/system-connections"
    ];
    files = [
      "/etc/machine-id"
      "/etc/ssh/ssh_host_rsa_key"
      "/etc/ssh/ssh_host_rsa_key.pub"
      "/etc/ssh/ssh_host_ed25519_key"
      "/etc/ssh/ssh_host_ed25519_key.pub"
    ];
  };
}
```

This gives me the following in `/etc/fstab`:
```
/persistent/etc/NetworkManager/system-connections /etc/NetworkManager/system-connections auto bind 0 2
/persistent/etc/machine-id /etc/machine-id auto bind 0 2
/persistent/etc/nixos /etc/nixos auto bind 0 2
/persistent/etc/ssh/ssh_host_ed25519_key /etc/ssh/ssh_host_ed25519_key auto bind 0 2
/persistent/etc/ssh/ssh_host_ed25519_key.pub /etc/ssh/ssh_host_ed25519_key.pub auto bind 0 2
/persistent/etc/ssh/ssh_host_rsa_key /etc/ssh/ssh_host_rsa_key auto bind 0 2
/persistent/etc/ssh/ssh_host_rsa_key.pub /etc/ssh/ssh_host_rsa_key.pub auto bind 0 2
```

And the following in `/var/run/current-system/activate`
```bash
#### Activation script snippet createFilesAndDirsIn--persistent:
_localstatus=0
mkdir -p $(dirname "/etc/machine-id") $(dirname "/persistent/etc/machine-id") &&
  touch "/etc/machine-id" "/persistent/etc/machine-id"
mkdir -p $(dirname "/etc/ssh/ssh_host_rsa_key") $(dirname "/persistent/etc/ssh/ssh_host_rsa_key") &&
  touch "/etc/ssh/ssh_host_rsa_key" "/persistent/etc/ssh/ssh_host_rsa_key"
mkdir -p $(dirname "/etc/ssh/ssh_host_rsa_key.pub") $(dirname "/persistent/etc/ssh/ssh_host_rsa_key.pub") &&
  touch "/etc/ssh/ssh_host_rsa_key.pub" "/persistent/etc/ssh/ssh_host_rsa_key.pub"
mkdir -p $(dirname "/etc/ssh/ssh_host_ed25519_key") $(dirname "/persistent/etc/ssh/ssh_host_ed25519_key") &&
  touch "/etc/ssh/ssh_host_ed25519_key" "/persistent/etc/ssh/ssh_host_ed25519_key"
mkdir -p $(dirname "/etc/ssh/ssh_host_ed25519_key.pub") $(dirname "/persistent/etc/ssh/ssh_host_ed25519_key.pub") &&
  touch "/etc/ssh/ssh_host_ed25519_key.pub" "/persistent/etc/ssh/ssh_host_ed25519_key.pub"
mkdir -p "/etc/nixos" "/persistent/etc/nixos"
mkdir -p "/etc/NetworkManager/system-connections" "/persistent/etc/NetworkManager/system-connections"
```