### PR TITLE
nixos: bind mount with correct permissions

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -88,15 +88,66 @@ in
     system.activationScripts =
       let
         # Create a directory in persistent storage, so we can bind
-        # mount it.
-        mkDirCreationSnippet = persistentStoragePath: dir:
-          let
-            targetDir = concatPaths [ persistentStoragePath dir ];
-          in
+        # mount it. The directory structure's mode and ownership mirror those of
+        # persistentStoragePath/dir;
+        # TODO: Move this script to it's own file, add CI with shfmt/shellcheck.
+        mkDirWithPerms = persistentStoragePath: dir:
           ''
-            if [[ ! -e "${targetDir}" ]]; then
-                mkdir -p "${targetDir}"
+            # Given a source directory, /source, and a target directory,
+            # /target/foo/bar/bazz, we want to "clone" the target structure
+            # from source into the target. Essentially, we want both
+            # /source/target/foo/bar/bazz and /target/foo/bar/bazz to exist
+            # on the filesystem. More concretely, we'd like to map
+            # /state/etc/ssh/example.key to /etc/ssh/example.key
+            #
+            # To achieve this, we split the target's path into parts -- target, foo,
+            # bar, bazz -- and iterate over them while accumulating the path
+            # (/target/, /target/foo/, /target/foo/bar, and so on); then, for each of
+            # these increasingly qualified paths we:
+            #
+            #   1. Ensure both /source/qualifiedPath and qualifiedPath exist
+            #   2. Copy the ownership of the source path into the target path
+            #   3. Copy the mode of the source path into the target path
+            (
+            # capture the nix vars into bash to avoid escape hell
+            sourceBase="${persistentStoragePath}"
+            target="${dir}"
+
+            # trim trailing slashes the root of all evil
+            sourceBase="''${sourceBase%/}"
+            target="''${target%/}"
+
+            # check that the source exists, if it doesn't exit the underlying
+            # scope (the activation script will continue)
+            realSource="$(realpath "$sourceBase$target")"
+            if [ ! -d "$realSource" ]; then
+                printf "\e[1;31mBind source '%s' does not exist; it will be created for you.\e[0m\n" "$realSource"
             fi
+
+            # iterate over each part of the target path, e.g. var, lib, iwd
+            previousPath="/"
+            for pathPart in $(echo "$target" | tr "/" " "); do
+              # construct the incremental path, e.g. /var, /var/lib, /var/lib/iwd
+              currentTargetPath="$previousPath$pathPart/"
+
+              # construct the source path, e.g. /state/var, /state/var/lib, ...
+              currentSourcePath="$sourceBase$currentTargetPath"
+
+              # create the source and target directories if they don't exist
+              [ -d "$currentSourcePath" ] || mkdir "$currentSourcePath"
+              [ -d "$currentTargetPath" ] || mkdir "$currentTargetPath"
+
+              # resolve the source path to avoid symlinks
+              currentRealSourcePath="$(realpath "$currentSourcePath")"
+
+              # synchronize perms between source and target
+              chown --reference="$currentRealSourcePath" "$currentTargetPath"
+              chmod --reference="$currentRealSourcePath" "$currentTargetPath"
+
+              # lastly we update the previousPath to continue down the tree
+              previousPath="$currentTargetPath"
+            done
+            )
           '';
 
         # Build an activation script which creates all persistent
@@ -105,7 +156,7 @@ in
           nameValuePair
             "createDirsIn-${replaceStrings [ "/" "." " " ] [ "-" "" "" ] persistentStoragePath}"
             (noDepEntry (concatMapStrings
-              (mkDirCreationSnippet persistentStoragePath)
+              (mkDirWithPerms persistentStoragePath)
               cfg.${persistentStoragePath}.directories
             ));
       in


### PR DESCRIPTION
This is yet another step towards #1.

With this the full directory structure is replicated with the correct permissions, thus allowing for non-root files and dirs to be bind-mounted. This enforces that the directories and files in the ephemeral storage have exactly matching ownership to their persistent storage correspondents.

I've tested this locally and have managed to bind mount things in my homedir without major issues.

It increases our bash complexity a little bit, but I tried to make the code well documented.