### PR TITLE
home-manager: Bind mount directories instead of symlinking them

### DIFF
--- a/README.org
+++ b/README.org
@@ -58,7 +58,7 @@
     one you don't, you can use both by defining two separate
     attributes under ~environment.persistence~.
 
-    IMPORTANT NOTE: Make sure your persistent volumes are marked with
+    /Important note:/ Make sure your persistent volumes are marked with
     ~neededForBoot~, otherwise you will run into problems.
 
 *** home-manager
@@ -136,18 +136,22 @@
     removes the first part of the path when deciding where to put the
     links.
 
-** Further reading
-The following blog posts provide more information on the concept of ephemeral
-roots:
+    /Note:/ Since this module uses the ~bindfs~ fuse filesystem for
+    directories, the names of the directories you add will be visible
+    in the ~/etc/mtab~ file and in the output of ~mount~ to all users.
 
-- https://elis.nu/blog/2020/05/nixos-tmpfs-as-root/ --- [[https://github.com/etu/][@etu]]'s blog post walks
-  the reader through a NixOS-on-tmpfs installation.
-- https://grahamc.com/blog/erase-your-darlings --- [[https://github.com/grahamc/][@grahamc]]'s blog post details
-  why one would want to erase their state at every boot, as well as how to
-  achieve this using ZFS snapshots.
+** Further reading
+   The following blog posts provide more information on the concept of ephemeral
+   roots:
+
+   - https://elis.nu/blog/2020/05/nixos-tmpfs-as-root/ --- [[https://github.com/etu/][@etu]]'s blog post walks
+     the reader through a NixOS-on-tmpfs installation.
+   - https://grahamc.com/blog/erase-your-darlings --- [[https://github.com/grahamc/][@grahamc]]'s blog post details
+     why one would want to erase their state at every boot, as well as how to
+     achieve this using ZFS snapshots.
 
 ** About the name
-: Impermanence, also known as the philosophical problem of change, is a
-: philosophical concept that is addressed in a variety of religions and
-: philosophies. In Eastern philosophy it is best known for its role in the
-: Buddhist three marks of existence. It also is an element of Hinduism.
+   : Impermanence, also known as the philosophical problem of change, is a
+   : philosophical concept that is addressed in a variety of religions and
+   : philosophies. In Eastern philosophy it is best known for its role in the
+   : Buddhist three marks of existence. It also is an element of Hinduism.

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -6,7 +6,7 @@ let
 
   persistentStoragePaths = attrNames cfg;
 
-  inherit (pkgs.callPackage ./lib.nix { }) splitPath dirListToPath concatPaths;
+  inherit (pkgs.callPackage ./lib.nix { }) splitPath dirListToPath concatPaths sanitizeName;
 in
 {
   options = {
@@ -43,53 +43,175 @@ in
       let
         link = file:
           pkgs.runCommand
-            "${replaceStrings [ "/" "." " " ] [ "-" "" "" ] file}"
+            "${sanitizeName file}"
             { }
             "ln -s '${file}' $out";
 
-        mkLinkNameValuePair = persistentStoragePath: fileOrDir: {
+        mkLinkNameValuePair = persistentStoragePath: file: {
           name =
             if cfg.${persistentStoragePath}.removePrefixDirectory then
-              dirListToPath (tail (splitPath [ fileOrDir ]))
+              dirListToPath (tail (splitPath [ file ]))
             else
-              fileOrDir;
-          value = { source = link (concatPaths [ persistentStoragePath fileOrDir ]); };
+              file;
+          value = { source = link (concatPaths [ persistentStoragePath file ]); };
         };
 
         mkLinksToPersistentStorage = persistentStoragePath:
           listToAttrs (map
             (mkLinkNameValuePair persistentStoragePath)
-            (cfg.${persistentStoragePath}.files ++ cfg.${persistentStoragePath}.directories)
+            (cfg.${persistentStoragePath}.files)
           );
       in
       foldl' recursiveUpdate { } (map mkLinksToPersistentStorage persistentStoragePaths);
+
+    systemd.user.services =
+      let
+        mkBindMountService = persistentStoragePath: dir:
+          let
+            mountDir =
+              if cfg.${persistentStoragePath}.removePrefixDirectory then
+                dirListToPath (tail (splitPath [ dir ]))
+              else
+                dir;
+            targetDir = concatPaths [ persistentStoragePath dir ];
+            mountPoint = concatPaths [ config.home.homeDirectory mountDir ];
+            name = "bindMount-${sanitizeName targetDir}";
+            startScript = pkgs.writeShellScript name ''
+              set -eu
+              if ! ${pkgs.utillinux}/bin/mount | ${pkgs.gnugrep}/bin/grep -E '${mountPoint}( |/)'; then
+                  ${pkgs.bindfs}/bin/bindfs -f --no-allow-other "${targetDir}" "${mountPoint}"
+              else
+                  echo "There is already an active mount at or below ${mountPoint}!" >&2
+                  exit 1
+              fi
+            '';
+            stopScript = pkgs.writeShellScript "unmount-${name}" ''
+              fusermount -uz "${mountPoint}"
+            '';
+          in
+          {
+            inherit name;
+            value = {
+              Unit = {
+                Description = "Bind mount ${targetDir} at ${mountPoint}";
+                PartOf = [ "graphical-session-pre.target" ];
+
+                # Don't restart the unit, it could corrupt data and
+                # crash programs currently reading from the mount.
+                X-RestartIfChanged = false;
+              };
+
+              Install.WantedBy = [ "default.target" ];
+
+              Service = {
+                ExecStart = "${startScript}";
+                ExecStop = "${stopScript}";
+              };
+            };
+          };
+
+        mkBindMountServicesForPath = persistentStoragePath:
+          listToAttrs (map
+            (mkBindMountService persistentStoragePath)
+            cfg.${persistentStoragePath}.directories
+          );
+      in
+      builtins.foldl'
+        recursiveUpdate
+        { }
+        (map mkBindMountServicesForPath persistentStoragePaths);
 
     home.activation =
       let
         dag = config.lib.dag;
 
-        mkDirCreationSnippet = persistentStoragePath: dir:
+        mkBindMount = persistentStoragePath: dir:
           let
+            mountDir =
+              if cfg.${persistentStoragePath}.removePrefixDirectory then
+                dirListToPath (tail (splitPath [ dir ]))
+              else
+                dir;
             targetDir = concatPaths [ persistentStoragePath dir ];
+            mountPoint = concatPaths [ config.home.homeDirectory mountDir ];
+            systemctl = "XDG_RUNTIME_DIR=\${XDG_RUNTIME_DIR:-/run/user/$(id -u)} ${config.systemd.user.systemctlPath}";
           in
           ''
             if [[ ! -e "${targetDir}" ]]; then
                 mkdir -p "${targetDir}"
             fi
+            if [[ ! -e "${mountPoint}" ]]; then
+                mkdir -p "${mountPoint}"
+            fi
+            if ${pkgs.utillinux}/bin/mount | grep "${mountPoint}"; then
+                if ! ${pkgs.utillinux}/bin/mount | grep "${mountPoint}" | grep "${targetDir}"; then
+                    # The target directory changed, so we need to remount
+                    echo "remounting ${mountPoint}"
+                    ${systemctl} --user stop bindMount-${sanitizeName targetDir}
+                    ${pkgs.bindfs}/bin/bindfs --no-allow-other "${targetDir}" "${mountPoint}"
+                    mountedPaths["${mountPoint}"]=1
+                fi
+            else
+                ${pkgs.bindfs}/bin/bindfs --no-allow-other "${targetDir}" "${mountPoint}"
+                mountedPaths["${mountPoint}"]=1
+            fi
           '';
 
-        mkDirCreationScriptForPath = persistentStoragePath: {
-          name = "createDirsIn-${replaceStrings [ "/" "." " " ] [ "-" "" "" ] persistentStoragePath}";
-          value =
-            dag.entryAfter
-              [ "writeBoundary" ]
-              (concatMapStrings
-                (mkDirCreationSnippet persistentStoragePath)
-                cfg.${persistentStoragePath}.directories
-              );
-        };
+        mkBindMountsForPath = persistentStoragePath:
+          concatMapStrings
+            (mkBindMount persistentStoragePath)
+            cfg.${persistentStoragePath}.directories;
+
+        mkUnmount = persistentStoragePath: dir:
+          let
+            mountDir =
+              if cfg.${persistentStoragePath}.removePrefixDirectory then
+                dirListToPath (tail (splitPath [ dir ]))
+              else
+                dir;
+            mountPoint = concatPaths [ config.home.homeDirectory mountDir ];
+          in
+          ''
+            if [[ -n ''${mountedPaths["${mountPoint}"]+x} ]]; then
+                fusermount -u "${mountPoint}"
+            fi
+          '';
+
+        mkUnmountsForPath = persistentStoragePath:
+          concatMapStrings
+            (mkUnmount persistentStoragePath)
+            cfg.${persistentStoragePath}.directories;
+
       in
-      listToAttrs (map mkDirCreationScriptForPath persistentStoragePaths);
+      mkIf (any (path: cfg.${path}.directories != [ ]) persistentStoragePaths) {
+        createAndMountPersistentStoragePaths =
+          dag.entryBefore
+            [ "writeBoundary" ]
+            ''
+              declare -A mountedPaths
+              ${(concatMapStrings mkBindMountsForPath persistentStoragePaths)}
+            '';
+
+        unmountPersistentStoragePaths =
+          dag.entryBefore
+            [ "createAndMountPersistentStoragePaths" ]
+            ''
+              unmountBindMounts() {
+              ${concatMapStrings mkUnmountsForPath persistentStoragePaths}
+              }
+
+              # Run the unmount function on error to clean up stray
+              # bind mounts
+              trap "unmountBindMounts" ERR
+            '';
+
+        runUnmountPersistentStoragePaths =
+          dag.entryBefore
+            [ "reloadSystemD" ]
+            ''
+              unmountBindMounts
+            '';
+      };
   };
 
 }

--- a/lib.nix
+++ b/lib.nix
@@ -18,5 +18,10 @@ let
       path = dirListToPath (splitPath paths);
     in
     prefix + path;
+
+  sanitizeName = name:
+    replaceStrings
+      [ "." ] [ "" ]
+      (strings.sanitizeDerivationName (removePrefix "/" name));
 in
-{ inherit splitPath dirListToPath concatPaths; }
+{ inherit splitPath dirListToPath concatPaths sanitizeName; }


### PR DESCRIPTION
Use `bindfs` to create bind mounts for directories instead of symlinking them. This should be less problematic for many applications, since bind mounts are much more transparent.

One service per bind mount is created to keep track of it. In addition, a bind mount is briefly created in the activation script, before `home-manager` switches to the new profile generation, and torn down again at the end of the activation script. This is done to ensure that the links `home-manager` creates end up in the right place; the user services aren't started until either the end of the activation script or the user session begins, and then it's too late.