### PR TITLE
nixos: Only check file systems for neededForBoot

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -165,7 +165,11 @@ in
     assertions =
       let
         files = concatMap (p: p.files or [ ]) (attrValues cfg);
-        markedNeededForBoot = cond: fs: (config.fileSystems.${fs}.neededForBoot == cond);
+        markedNeededForBoot = cond: fs:
+          if config.fileSystems ? ${fs} then
+            (config.fileSystems.${fs}.neededForBoot == cond)
+          else
+            cond;
       in
       [
         {


### PR DESCRIPTION
Only assert that persistent paths are marked neededForBoot if they're
file system roots.

Fixes #12