### PR TITLE
Create directories file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,41 @@
 name: CI
 on: [push, pull_request]
 jobs:
-  parsing:
+  nix_parsing:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v12
-      - name: Check Nix Parsing
+      - name: Check Nix parsing
         run: |
           find . -name "*.nix" -exec nix-instantiate --parse --quiet {} >/dev/null +
-  format:
+  nix_formatting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - name: Check Nix Formatting
+      - name: Check Nix formatting
         run: |
           nix run nixpkgs.nixpkgs-fmt -c nixpkgs-fmt --check .
+  shell_formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Check shell script formatting
+        run: |
+          find . -name "*.*sh" -exec nix run nixpkgs.shfmt -c shfmt -i 4 -d {} +
+  shell_error_checking:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Check for shell script errors
+        run: |
+          find . -name "*.*sh" -exec nix run nixpkgs.shellcheck -c shellcheck {} +

--- a/create-directories.bash
+++ b/create-directories.bash
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+set -o errtrace
+
+trap 'echo Error when executing ${BASH_COMMAND} at line ${LINENO}! >&2' ERR
+
+# Given a source directory, /source, and a target directory,
+# /target/foo/bar/bazz, we want to "clone" the target structure
+# from source into the target. Essentially, we want both
+# /source/target/foo/bar/bazz and /target/foo/bar/bazz to exist
+# on the filesystem. More concretely, we'd like to map
+# /state/etc/ssh/example.key to /etc/ssh/example.key
+#
+# To achieve this, we split the target's path into parts -- target, foo,
+# bar, bazz -- and iterate over them while accumulating the path
+# (/target/, /target/foo/, /target/foo/bar, and so on); then, for each of
+# these increasingly qualified paths we:
+#   1. Ensure both /source/qualifiedPath and qualifiedPath exist
+#   2. Copy the ownership of the source path to the target path
+#   3. Copy the mode of the source path to the target path
+
+# Get inputs from command line arguments
+if [[ "$#" != 2 ]]; then
+    printf "Error: 'create-directories.bash' requires *two* args.\n" >&2
+    exit 1
+fi
+sourceBase="$1"
+target="$2"
+
+# trim trailing slashes the root of all evil
+sourceBase="${sourceBase%/}"
+target="${target%/}"
+
+# check that the source exists and warn the user if it doesn't
+realSource="$(realpath "$sourceBase$target")"
+if [[ ! -d "$realSource" ]]; then
+    printf "Warning: Source directory '%s' does not exist; it will be created for you. Make sure the permissions are correct!\n" "$realSource"
+fi
+
+# iterate over each part of the target path, e.g. var, lib, iwd
+previousPath="/"
+for pathPart in $(echo "$target" | tr "/" " "); do
+    # construct the incremental path, e.g. /var, /var/lib, /var/lib/iwd
+    currentTargetPath="$previousPath$pathPart/"
+
+    # construct the source path, e.g. /state/var, /state/var/lib, ...
+    currentSourcePath="$sourceBase$currentTargetPath"
+
+    # create the source and target directories if they don't exist
+    [[ -d "$currentSourcePath" ]] || mkdir "$currentSourcePath"
+    [[ -d "$currentTargetPath" ]] || mkdir "$currentTargetPath"
+
+    # resolve the source path to avoid symlinks
+    currentRealSourcePath="$(realpath "$currentSourcePath")"
+
+    # synchronize perms between source and target
+    chown --reference="$currentRealSourcePath" "$currentTargetPath"
+    chmod --reference="$currentRealSourcePath" "$currentTargetPath"
+
+    # lastly we update the previousPath to continue down the tree
+    previousPath="$currentTargetPath"
+done

--- a/nixos.nix
+++ b/nixos.nix
@@ -105,67 +105,13 @@ in
 
     system.activationScripts =
       let
-        # Script to create a directory in persistent storage, so we can bind
-        # mount it. The directory structure's mode and ownership mirror those of
-        # persistentStoragePath/dir;
-        # TODO: Move this script to it's own file, add CI with shfmt/shellcheck.
-        createDirectories = pkgs.writeShellScript "impermanence-create-directories"
-          ''
-            # Given a source directory, /source, and a target directory,
-            # /target/foo/bar/bazz, we want to "clone" the target structure
-            # from source into the target. Essentially, we want both
-            # /source/target/foo/bar/bazz and /target/foo/bar/bazz to exist
-            # on the filesystem. More concretely, we'd like to map
-            # /state/etc/ssh/example.key to /etc/ssh/example.key
-            #
-            # To achieve this, we split the target's path into parts -- target, foo,
-            # bar, bazz -- and iterate over them while accumulating the path
-            # (/target/, /target/foo/, /target/foo/bar, and so on); then, for each of
-            # these increasingly qualified paths we:
-            #
-            #   1. Ensure both /source/qualifiedPath and qualifiedPath exist
-            #   2. Copy the ownership of the source path into the target path
-            #   3. Copy the mode of the source path into the target path
-
-            # Get inputs from command line arguments
-            sourceBase="$1"
-            target="$2"
-
-            # trim trailing slashes the root of all evil
-            sourceBase="''${sourceBase%/}"
-            target="''${target%/}"
-
-            # check that the source exists, if it doesn't exit the underlying
-            # scope (the activation script will continue)
-            realSource="$(realpath "$sourceBase$target")"
-            if [ ! -d "$realSource" ]; then
-                printf "\e[1;31mBind source '%s' does not exist; it will be created for you.\e[0m\n" "$realSource"
-            fi
-
-            # iterate over each part of the target path, e.g. var, lib, iwd
-            previousPath="/"
-            for pathPart in $(echo "$target" | tr "/" " "); do
-              # construct the incremental path, e.g. /var, /var/lib, /var/lib/iwd
-              currentTargetPath="$previousPath$pathPart/"
-
-              # construct the source path, e.g. /state/var, /state/var/lib, ...
-              currentSourcePath="$sourceBase$currentTargetPath"
-
-              # create the source and target directories if they don't exist
-              [ -d "$currentSourcePath" ] || mkdir "$currentSourcePath"
-              [ -d "$currentTargetPath" ] || mkdir "$currentTargetPath"
-
-              # resolve the source path to avoid symlinks
-              currentRealSourcePath="$(realpath "$currentSourcePath")"
-
-              # synchronize perms between source and target
-              chown --reference="$currentRealSourcePath" "$currentTargetPath"
-              chmod --reference="$currentRealSourcePath" "$currentTargetPath"
-
-              # lastly we update the previousPath to continue down the tree
-              previousPath="$currentTargetPath"
-            done
-          '';
+        # Script to create directories in persistent and ephemeral
+        # storage. The directory structure's mode and ownership mirror
+        # those of persistentStoragePath/dir.
+        createDirectories = pkgs.runCommand "impermanence-create-directories" { } ''
+          cp ${./create-directories.bash} $out
+          patchShebangs $out
+        '';
 
         mkDirWithPerms = persistentStoragePath: dir: ''
           ${createDirectories} "${persistentStoragePath}" "${dir}"

--- a/nixos.nix
+++ b/nixos.nix
@@ -120,11 +120,15 @@ in
         # Build an activation script which creates all persistent
         # storage directories we want to bind mount.
         mkDirCreationScriptForPath = persistentStoragePath:
+          let
+            directories = cfg.${persistentStoragePath}.directories;
+            files = unique (map dirOf cfg.${persistentStoragePath}.files);
+          in
           nameValuePair
             "createDirsIn-${replaceStrings [ "/" "." " " ] [ "-" "" "" ] persistentStoragePath}"
             (noDepEntry (concatMapStrings
               (mkDirWithPerms persistentStoragePath)
-              cfg.${persistentStoragePath}.directories
+              (directories ++ files)
             ));
       in
       listToAttrs (map mkDirCreationScriptForPath persistentStoragePaths);


### PR DESCRIPTION
Extract the `createDirectories` script out into its own file and add CI checks. Also, run the script for directories of files in persistent storage, not just pure directories.