### PR TITLE
Fix bindfs unmounts and remounts

### DIFF
--- a/README.org
+++ b/README.org
@@ -92,17 +92,14 @@
             "Documents"
             "Videos"
             "VirtualBox VMs"
-            ".gnupg/private-keys-v1.d"
+            ".gnupg"
             ".ssh"
             ".nixops"
             ".local/share/keyrings"
             ".local/share/direnv"
           ];
           files = [
-            ".gnupg/pubring.kbx"
-            ".gnupg/sshcontrol"
-            ".gnupg/trustdb.gpg"
-            ".gnupg/random_seed"
+            ".screenrc"
           ];
         };
       }

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -139,6 +139,15 @@ in
       let
         dag = config.lib.dag;
 
+        # The name of the activation script entry responsible for
+        # reloading systemd user services. The name was initially
+        # `reloadSystemD` but has been changed to `reloadSystemd`.
+        reloadSystemd =
+          if config.home.activation ? reloadSystemD then
+            "reloadSystemD"
+          else
+            "reloadSystemd";
+
         mkBindMount = persistentStoragePath: dir:
           let
             mountDir =
@@ -238,7 +247,7 @@ in
 
         runUnmountPersistentStoragePaths =
           dag.entryBefore
-            [ "reloadSystemD" ]
+            [ reloadSystemd ]
             ''
               unmountBindMounts
             '';

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -169,12 +169,14 @@ in
                 mkdir -p ${mountPoint}
             fi
             if ${mount} | grep -F ${mountPoint}' ' >/dev/null; then
-                if ! ${mount} | grep -F ${mountPoint}' ' | grep -F ${targetDir} >/dev/null; then
-                    # The target directory changed, so we need to remount
-                    echo "remounting ${mountPoint}"
-                    ${systemctl} --user stop bindMount-${sanitizeName targetDir}
-                    ${bindfs} --no-allow-other ${targetDir} ${mountPoint}
-                    mountedPaths[${mountPoint}]=1
+                if ! ${mount} | grep -F ${mountPoint}' ' | grep -F bindfs; then
+                    if ! ${mount} | grep -F ${mountPoint}' ' | grep -F ${targetDir} >/dev/null; then
+                        # The target directory changed, so we need to remount
+                        echo "remounting ${mountPoint}"
+                        ${systemctl} --user stop bindMount-${sanitizeName targetDir}
+                        ${bindfs} --no-allow-other ${targetDir} ${mountPoint}
+                        mountedPaths[${mountPoint}]=1
+                    fi
                 fi
             elif ${mount} | grep -F ${mountPoint}/ >/dev/null; then
                 echo "Something is mounted below ${mountPoint}, not creating bind mount to ${targetDir}" >&2

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -20,16 +20,51 @@ in
               directories = mkOption {
                 type = with types; listOf str;
                 default = [ ];
+                example = [
+                  "Downloads"
+                  "Music"
+                  "Pictures"
+                  "Documents"
+                  "Videos"
+                  "VirtualBox VMs"
+                  ".gnupg"
+                  ".ssh"
+                  ".local/share/keyrings"
+                  ".local/share/direnv"
+                ];
+                description = ''
+                  A list of directories in your home directory that
+                  you want to link to persistent storage.
+                '';
               };
 
               files = mkOption {
                 type = with types; listOf str;
                 default = [ ];
+                example = [
+                  ".screenrc"
+                ];
+                description = ''
+                  A list of files in your home directory you want to
+                  link to persistent storage.
+                '';
               };
 
               removePrefixDirectory = mkOption {
                 type = types.bool;
                 default = false;
+                example = true;
+                description = ''
+                  Note: This is mainly useful if you have a dotfiles
+                  repo structured for use with GNU Stow; if you don't,
+                  you can likely ignore it.
+
+                  Whether to remove the first directory when linking
+                  or mounting; e.g. for the path
+                  <literal>"screen/.screenrc"</literal>, the
+                  <literal>screen/</literal> is ignored for the path
+                  linked to in your home directory.
+                '';
               };
             };
         }


### PR DESCRIPTION
Due to what is likely a bug in `bindfs` or `fuse`, the target path is sometimes missing from the mount entry. This causes false positives for the target directory having changed, leading to unnecessary remounts. Luckily, it seems that when this happens, the line instead contains the string `bindfs`, which it doesn't normally, so we can at least circumvent this issue to some degree.

Also, find the correct name of the activation script entry responsible for reloading systemd user services. The name was initially `reloadSystemD` but has been changed to `reloadSystemd`, causing failures due to the unmounts being done after the systemd services are reloaded.

Fixes #36