### PR TITLE
home-manager: Add `allowOther` option to let other users read bind mounts

### DIFF
--- a/README.org
+++ b/README.org
@@ -101,6 +101,7 @@
           files = [
             ".screenrc"
           ];
+          allowOther = true;
         };
       }
     #+end_src
@@ -108,6 +109,10 @@
     - ~"/persistent/home/talyz"~ is the path to your persistent storage location
     - ~directories~ are all directories you want to link to persistent storage
     - ~files~ are all files you want to link to persistent storage
+    - ~allowOther~ allows other users, such as ~root~, to access files
+      through the bind mounted directories listed in
+      ~directories~. Useful for ~sudo~ operations, Docker, etc. Requires
+      the NixOS configuration ~programs.fuse.userAllowOther = true~.
 
     Additionally, the ~home-manager~ module allows for compatibility
     with ~dotfiles~ repos structured for use with [[https://www.gnu.org/software/stow/][GNU Stow]], where the

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -232,12 +232,9 @@ in
             systemctl = "XDG_RUNTIME_DIR=\${XDG_RUNTIME_DIR:-/run/user/$(id -u)} ${config.systemd.user.systemctlPath}";
           in
           ''
-            if [[ ! -e ${targetDir} ]]; then
-                mkdir -p ${targetDir}
-            fi
-            if [[ ! -e ${mountPoint} ]]; then
-                mkdir -p ${mountPoint}
-            fi
+            mkdir -p ${targetDir}
+            mkdir -p ${mountPoint}
+
             if ${mount} | grep -F ${mountPoint}' ' >/dev/null; then
                 if ! ${mount} | grep -F ${mountPoint}' ' | grep -F bindfs; then
                     if ! ${mount} | grep -F ${mountPoint}' ' | grep -F ${targetDir}' ' >/dev/null; then

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -144,6 +144,7 @@ in
             startScript = pkgs.writeShellScript name ''
               set -eu
               if ! mount | grep -F ${mountPoint}' ' && ! mount | grep -F ${mountPoint}/; then
+                  mkdir -p ${mountPoint}
                   ${bindfs} ${targetDir} ${mountPoint}
               else
                   echo "There is already an active mount at or below ${mountPoint}!" >&2


### PR DESCRIPTION
NixOS defaults to not letting fuse mounts be allowed to let other users read their contents. `bindfs` wants to give other users access and is therefore normally run with `--no-allow-other` to not throw an error.

Giving other users, mainly `root`, access to the bind mounts is, however, useful and works fine when
```nix
{
  programs.fuse.userAllowOther = true;
}
```

is declared in `configuration.nix`. This adds an option to choose whether to give other users access or not. It also prompts the user to set the `allowOther` attribute with a link to the documentation.

Should be merged after #38.

Fixes #35 