### PR TITLE
Added home manager module to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
   outputs = { self }: {
     nixosModules.impermanence = import ./nixos.nix;
+    nixosModules.home-manager.impermanence = import ./home-manager.nix;
   };
 }


### PR DESCRIPTION
`home-manager.nix` wasn't being added to `nixosModules` on `flake.nix`.
Added it as `impermanence-home`.