### PR TITLE
nixos: Manage files using systemd services

### DIFF
--- a/README.org
+++ b/README.org
@@ -51,7 +51,7 @@
 
     - ~"/persistent"~ is the path to your persistent storage location
     - ~directories~ are all directories you want to bind mount to persistent storage
-    - ~files~ are all files you want to link to persistent storage (only in ~/etc~ for now)
+    - ~files~ are all files you want to link to persistent storage
 
     This allows for multiple different persistent storage
     locations. If you, for example, have one location you back up and


### PR DESCRIPTION
Manage files by creating a systemd oneshot service for each file. The service links or bind mounts the file as appropriate on start and removes the link or unmounts it when stopped. Whether a symlink or bind mount is used is determined by if the target exists - if it does, it's bind mounted, otherwise symlinked. To make sure files are available early enough, also run the start portion in the activation script.

This lifts the restriction on files being placed in `/etc` and should finally close #1.