### PR TITLE
home-manager: Use bash exec when calling bindfs

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -145,7 +145,7 @@ in
               set -eu
               if ! mount | grep -F ${mountPoint}' ' && ! mount | grep -F ${mountPoint}/; then
                   mkdir -p ${mountPoint}
-                  ${bindfs} ${targetDir} ${mountPoint}
+                  exec ${bindfs} ${targetDir} ${mountPoint}
               else
                   echo "There is already an active mount at or below ${mountPoint}!" >&2
                   exit 1


### PR DESCRIPTION
Right now the shell script wrapper doesn't exit which results in a lot of unnecessary bash processes.