### PR TITLE
home-manager: Start the bind units as early as possible

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -178,9 +178,21 @@ in
                 # Don't restart the unit, it could corrupt data and
                 # crash programs currently reading from the mount.
                 X-RestartIfChanged = false;
+
+                # Don't add an implicit After=basic.target.
+                DefaultDependencies = false;
+
+                Before = [
+                  "bluetooth.target"
+                  "basic.target"
+                  "default.target"
+                  "paths.target"
+                  "sockets.target"
+                  "timers.target"
+                ];
               };
 
-              Install.WantedBy = [ "default.target" ];
+              Install.WantedBy = [ "paths.target" ];
 
               Service = {
                 Type = "forking";


### PR DESCRIPTION
Make sure the bind mount units start as early as possible in the user session. This should hopefully make issues like #60 less prevalent.