### PR TITLE
nixos: Mount binds after the persistent storage path

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -120,6 +120,7 @@ in
             device = concatPaths [ persistentStoragePath dir ];
             noCheck = true;
             options = [ "bind" ];
+            depends = [ persistentStoragePath ];
           };
         };
 


### PR DESCRIPTION
This sets the `depends` (introduced in https://github.com/NixOS/nixpkgs/pull/86967) of each bind mount so that it will only be mounted after the persistent storage path has been mounted, as suggested in https://github.com/nix-community/impermanence/issues/22#issuecomment-847879359.

An obvious issue with this is that this will break older NixOS where the option does not exist yet. Any suggestions on how to work around that?