### PR TITLE
home-manager: Fix unquoted path when creating directories

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -344,7 +344,7 @@ in
                 (persistentStoragePath:
                   concatMapStrings
                     (targetFilePath: ''
-                      mkdir -p ${concatPaths [ persistentStoragePath (dirOf targetFilePath) ]}
+                      mkdir -p ${escapeShellArg (concatPaths [ persistentStoragePath (dirOf targetFilePath) ])}
                     '')
                     cfg.${persistentStoragePath}.files)
                 persistentStoragePaths);


### PR DESCRIPTION
Fixes #63 