### PR TITLE
nixos: Refactor and implement support for user files + directories

### DIFF
--- a/README.org
+++ b/README.org
@@ -40,10 +40,11 @@
             "/var/lib/bluetooth"
             "/var/lib/systemd/coredump"
             "/etc/NetworkManager/system-connections"
+            { directory = "/var/lib/colord"; user = "colord"; group = "colord"; mode = "u=rwx,g=rx,o="; }
           ];
           files = [
             "/etc/machine-id"
-            "/etc/nix/id_rsa"
+            { file = "/etc/nix/id_rsa"; parentDirectory = { mode = "u=rwx,g=,o="; }; }
           ];
           users.talyz = {
             directories = [
@@ -53,10 +54,10 @@
               "Documents"
               "Videos"
               "VirtualBox VMs"
-              ".gnupg"
-              ".ssh"
-              ".nixops"
-              ".local/share/keyrings"
+              { directory = ".gnupg"; mode = "0700"; }
+              { directory = ".ssh"; mode = "0700"; }
+              { directory = ".nixops"; mode = "0700"; }
+              { directory = ".local/share/keyrings"; mode = "0700"; }
               ".local/share/direnv"
             ];
             files = [
@@ -75,10 +76,63 @@
       attributes under ~environment.persistence~.
 
     - ~directories~ are all directories you want to bind mount to
-      persistent storage
+      persistent storage. A directory can be represented either as a
+      string, simply denoting its path, or as a submodule. The
+      submodule representation is useful when the default assumptions,
+      mainly regarding permissions, are incorrect. The available
+      options are:
+
+      - ~directory~, the path to the directory you want to bind mount
+        to persistent storage. Only setting this option is
+        equivalent to the string representation.
+
+      - ~persistentStoragePath~, the path to persistent
+        storage. Defaults to the ~environment.persistence~ submodule
+        name, i.e. ~"/persistent"~ in the example. This should most
+        likely be left to its default value - don't change it unless
+        you're certain you really need to.
+
+      - ~user~, the user who should own the directory. If the directory
+        doesn't already exist in persistent storage, it will be
+        created and this user will be its owner. This also applies to
+        any parent directories which don't yet exist. Changing this
+        once the directory has been created has no effect.
+
+      - ~group~, the group who should own the directory. If the
+        directory doesn't already exist in persistent storage, it will
+        be created and this group will be its owner. This also applies
+        to any parent directories which don't yet exist. Changing this
+        once the directory has been created has no effect.
+
+      - ~mode~, the permissions to set for the directory. If the
+        directory doesn't already exist in persistent storage, it will
+        be created with this mode. Can be either an octal mode
+        (e.g. ~0700~) or a symbolic mode (e.g. ~u=rwx,g=,o=~). This also
+        applies to any parent directories which don't yet exist.
+        Changing this once the directory has been created has no
+        effect.
 
     - ~files~ are all files you want to link or bind to persistent
-      storage
+      storage. A file can be represented either as a string, simply
+      denoting its path, or as a submodule. The submodule
+      representation is useful when the default assumptions, mainly
+      regarding the permissions of its parent directory, are
+      incorrect. The available options are:
+
+      - ~file~, the path to the file you want to bind mount to
+        persistent storage. Only setting this option is equivalent to
+        the string representation.
+
+      - ~persistentStoragePath~, the path to persistent
+        storage. Defaults to the ~environment.persistence~ submodule
+        name, i.e. ~"/persistent"~ in the example. This should most
+        likely be left to its default value - don't change it unless
+        you're certain you really need to.
+
+      - ~parentDirectory~, the permissions that should be applied to the
+        file's parent directory, if it doesn't already
+        exist. Available options are ~user~, ~group~ and ~mode~. See their
+        definition in ~directories~ above.
 
       If the file exists in persistent storage, it will be bind
       mounted to the target path; otherwise it will be symlinked.

--- a/README.org
+++ b/README.org
@@ -45,18 +45,56 @@
             "/etc/machine-id"
             "/etc/nix/id_rsa"
           ];
+          users.talyz = {
+            directories = [
+              "Downloads"
+              "Music"
+              "Pictures"
+              "Documents"
+              "Videos"
+              "VirtualBox VMs"
+              ".gnupg"
+              ".ssh"
+              ".nixops"
+              ".local/share/keyrings"
+              ".local/share/direnv"
+            ];
+            files = [
+              ".screenrc"
+            ];
+          };
         };
       }
     #+end_src
 
     - ~"/persistent"~ is the path to your persistent storage location
-    - ~directories~ are all directories you want to bind mount to persistent storage
-    - ~files~ are all files you want to link to persistent storage
 
-    This allows for multiple different persistent storage
-    locations. If you, for example, have one location you back up and
-    one you don't, you can use both by defining two separate
-    attributes under ~environment.persistence~.
+      This allows for multiple different persistent storage
+      locations. If you, for example, have one location you back up
+      and one you don't, you can use both by defining two separate
+      attributes under ~environment.persistence~.
+
+    - ~directories~ are all directories you want to bind mount to
+      persistent storage
+
+    - ~files~ are all files you want to link or bind to persistent
+      storage
+
+      If the file exists in persistent storage, it will be bind
+      mounted to the target path; otherwise it will be symlinked.
+
+    - ~users.talyz~ handles files and directories in ~talyz~'s home
+      directory
+
+      The ~users~ option defines a set of submodules which correspond to
+      the users' names. The ~directories~ and ~files~ options of each
+      submodule work like their root counterparts, but the paths are
+      automatically prefixed with with the user's home directory.
+
+      If the user has a non-standard home directory (i.e. not
+      ~/home/<username>~), the ~users.<username>.home~ option has to be
+      set to this path - it can't currently be automatically deduced
+      due to a limitation in ~nixpkgs~.
 
     /Important note:/ Make sure your persistent volumes are marked with
     ~neededForBoot~, otherwise you will run into problems.

--- a/lib.nix
+++ b/lib.nix
@@ -26,5 +26,26 @@ let
     replaceStrings
       [ "." ] [ "" ]
       (sanitizeDerivationName (removePrefix "/" name));
+
+  duplicates = list:
+    let
+      result =
+        foldl'
+          (state: item:
+            if elem item state.items then
+              {
+                items = state.items ++ [ item ];
+                duplicates = state.duplicates ++ [ item ];
+              }
+            else
+              state // {
+                items = state.items ++ [ item ];
+              })
+          { items = [ ]; duplicates = [ ]; }
+          list;
+    in
+    result.duplicates;
 in
-{ inherit splitPath dirListToPath concatPaths sanitizeName; }
+{
+  inherit splitPath dirListToPath concatPaths sanitizeName duplicates;
+}

--- a/lib.nix
+++ b/lib.nix
@@ -1,6 +1,9 @@
 { lib }:
-with lib;
 let
+  inherit (lib) filter concatMap concatStringsSep hasPrefix head
+    replaceStrings optionalString removePrefix foldl' elem;
+  inherit (lib.strings) sanitizeDerivationName;
+
   # ["/home/user/" "/.screenrc"] -> ["home" "user" ".screenrc"]
   splitPath = paths:
     (filter
@@ -22,6 +25,6 @@ let
   sanitizeName = name:
     replaceStrings
       [ "." ] [ "" ]
-      (strings.sanitizeDerivationName (removePrefix "/" name));
+      (sanitizeDerivationName (removePrefix "/" name));
 in
 { inherit splitPath dirListToPath concatPaths sanitizeName; }


### PR DESCRIPTION
An overhaul of the current NixOS module which adds a `users` feature, makes the module more extensible, adds permissions handling, and asserts that no duplicates are specified:

## Implement support for user files and directories

Allow user files and directories to be specified as follows:

```nix
{
  environment.persistence."/persistent" = {
    users.talyz = {
      files = [
        ".screenrc"
      ];
      directories = [
        "Downloads"
      ];
    };
  };
}
```

This provides an alternative to the home-manager module and may even deprecate it in the future.


## Refactor the module to simplify future extensibility

Implement support for a submodule representation for files and directories. Strings are automatically converted to appropriate submodule representations and each file and directory is handled based only on their respective submodule's attributes. This means that for most files, a string will suffice, but if more advanced options need to be set for the specific files or directories, a submodule can be used instead. It also, arguably, simplifies the implementation a bit.

## Add support for custom permissions on created directories

Building on the extensibility mentioned above, allow the owner and mode to be set when directories are created in persistent storage by the `create-directories.bash` script. Very useful for directories used to store secrets.

Also, make sure the user directories are created with reasonable defaults, i.e. owned by the user and its group, not by `root:root`.

Here is an example of this in use:

```nix
{
  environment.persistence."/persistent" = {
    directories = [
      "/var/log"
      "/etc/NetworkManager/system-connections"
      { directory = "/var/lib/colord"; user = "colord"; group = "colord"; mode = "u=rwx,g=rx,o="; }
    ];
    files = [
      "/etc/machine-id"
      { file = "/etc/nix/id_rsa"; parentDirectory = { mode = "u=rwx,g=,o="; }; }
    ];
    users.talyz = {
      directories = [
        "Downloads"
        "Music"
        { directory = ".gnupg"; mode = "0700"; }
        { directory = ".ssh"; mode = "0700"; }
        { directory = ".nixops"; mode = "0700"; }
        { directory = ".local/share/keyrings"; mode = "0700"; }
        ".local/share/direnv"
      ];
    };
  };
}
```

## Assert that no duplicate files or directories are specified

Make sure the same files or directories aren't specified multiple times, either between persistent storage paths or in the same path.