### PR TITLE
refactor: utillinux -> util-linux

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -198,7 +198,7 @@ in
                 Type = "forking";
                 ExecStart = "${startScript}";
                 ExecStop = "${stopScript}";
-                Environment = "PATH=${makeBinPath [ pkgs.coreutils pkgs.utillinux pkgs.gnugrep pkgs.bindfs ]}:/run/wrappers/bin";
+                Environment = "PATH=${makeBinPath [ pkgs.coreutils pkgs.util-linux pkgs.gnugrep pkgs.bindfs ]}:/run/wrappers/bin";
               };
             };
           };
@@ -236,7 +236,7 @@ in
                 dir;
             targetDir = escapeShellArg (concatPaths [ persistentStoragePath dir ]);
             mountPoint = escapeShellArg (concatPaths [ config.home.homeDirectory mountDir ]);
-            mount = "${pkgs.utillinux}/bin/mount";
+            mount = "${pkgs.util-linux}/bin/mount";
             bindfsOptions = concatStringsSep "," (
               optional (!cfg.${persistentStoragePath}.allowOther) "no-allow-other"
               ++ optional (versionAtLeast pkgs.bindfs.version "1.14.9") "fsname=${targetDir}"

--- a/nixos.nix
+++ b/nixos.nix
@@ -84,7 +84,7 @@ in
               description = "Bind mount or link ${targetFile} to ${mountPoint}";
               wantedBy = [ "local-fs.target" ];
               before = [ "local-fs.target" ];
-              path = [ pkgs.utillinux ];
+              path = [ pkgs.util-linux ];
               unitConfig.DefaultDependencies = false;
               serviceConfig = {
                 Type = "oneshot";


### PR DESCRIPTION
The `utillinux` package has been renamed to `util-linux` in `nixpkgs`, causing
our modules to fail to evaluate on `allowAliases = false` configurations.

This just makes us use the "new" name of `util-linux`.
