### PR TITLE
fix(nixos): allow eval to succeed when the module is unused

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -12,7 +12,8 @@ let
 
   cfg = config.environment.persistence;
   users = config.users.users;
-  allPersistentStoragePaths = zipAttrsWith (_name: flatten) (attrValues cfg);
+  allPersistentStoragePaths = { directories = [ ]; files = [ ]; users = [ ]; }
+    // (zipAttrsWith (_name: flatten) (attrValues cfg));
   inherit (allPersistentStoragePaths) files directories;
   mkMountScript = mountPoint: targetFile: ''
     if [[ -L ${mountPoint} && $(readlink -f ${mountPoint}) == ${targetFile} ]]; then


### PR DESCRIPTION
Fixes an issue from #70 where system configs won't eval if no
`environment.persist` confg exists.

~I think this fix is a little hacky, there's probably a better/clear way of
handling this.~ Thought of a better way.
