### PR TITLE
nixos: Fix the path splitting in create-directories.bash

### DIFF
--- a/create-directories.bash
+++ b/create-directories.bash
@@ -45,7 +45,16 @@ fi
 
 # iterate over each part of the target path, e.g. var, lib, iwd
 previousPath="/"
-for pathPart in $(echo "$target" | tr "/" " "); do
+
+OLD_IFS=$IFS
+IFS=/ # split the path on /
+for pathPart in $target; do
+    IFS=$OLD_IFS
+
+    # skip empty parts caused by the prefix slash and multiple
+    # consecutive slashes
+    [[ $pathPart == "" ]] && continue
+
     # construct the incremental path, e.g. /var, /var/lib, /var/lib/iwd
     currentTargetPath="$previousPath$pathPart/"
 


### PR DESCRIPTION
Paths are currently split on bash's default delimiters (space, tab and newline) with slashes converted to space. This means paths containing any such delimiters are incorrectly handled, as @etu reported here: https://github.com/nix-community/impermanence/issues/74#issuecomment-1027643883.

Fix this by temporarily replacing bash's default delimiters with `/`, making sure this is the only character we split on.