### PR TITLE
feat(nixos): Support Hiding of Bind Mounts

### DIFF
--- a/README.org
+++ b/README.org
@@ -35,6 +35,7 @@
     #+begin_src nix
       {
         environment.persistence."/persistent" = {
+          hideMounts = true;
           directories = [
             "/var/log"
             "/var/lib/bluetooth"
@@ -136,6 +137,11 @@
 
       If the file exists in persistent storage, it will be bind
       mounted to the target path; otherwise it will be symlinked.
+
+    - ~hideMounts~ allows you to specify whether to hide the
+      bind mounts from showing up as mounted drives in the file
+      manager. If enabled, it sets the mount option ~x-gvfs-hide~
+      on all the bind mounts.
 
     - ~users.talyz~ handles files and directories in ~talyz~'s home
       directory

--- a/nixos.nix
+++ b/nixos.nix
@@ -5,7 +5,7 @@ let
     types foldl' unique noDepEntry concatMapStrings listToAttrs
     escapeShellArg escapeShellArgs replaceStrings recursiveUpdate all
     filter filterAttrs concatStringsSep concatMapStringsSep isString
-    catAttrs;
+    catAttrs optional;
 
   inherit (pkgs.callPackage ./lib.nix { }) splitPath dirListToPath
     concatPaths sanitizeName duplicates;
@@ -38,7 +38,7 @@ in
       default = { };
       type =
         let
-          inherit (types) attrsOf listOf submodule path either str;
+          inherit (types) attrsOf bool listOf submodule path either str;
         in
         attrsOf (
           submodule (
@@ -263,6 +263,15 @@ in
                         else
                           directory);
                   };
+
+                  hideMounts = mkOption {
+                    type = bool;
+                    default = false;
+                    example = true;
+                    description = ''
+                      Whether to hide bind mounts from showing up as mounted drives.
+                    '';
+                  };
                 };
               config =
                 let
@@ -332,7 +341,8 @@ in
           value = {
             device = concatPaths [ persistentStoragePath directory ];
             noCheck = true;
-            options = [ "bind" ];
+            options = [ "bind" ]
+              ++ optional cfg.${persistentStoragePath}.hideMounts "x-gvfs-hide";
           };
         };
 


### PR DESCRIPTION
This is done by exposing an option `hideMounts` to set the `x-gvfs-hide` mount option on all the bind mounts

Fixes #64 