### PR TITLE
Add descriptions for module options

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -93,6 +93,14 @@ in
             };
         })
       );
+      description = ''
+        Persistent storage locations and the files and directories to
+        link to them. Each attribute name should be the path relative
+        to the user's home directory.
+
+        For detailed usage, check the <link
+        xlink:href="https://github.com/nix-community/impermanence">documentation</link>.
+      '';
     };
 
   };

--- a/nixos.nix
+++ b/nixos.nix
@@ -219,6 +219,22 @@ in
                       )
                     );
                     default = { };
+                    description = ''
+                      An alternative to the home-manager module on NixOS.
+                    '';
+                    example = ''
+                      {
+                        talyz = {
+                          files = [
+                            ".screenrc"
+                          ];
+                          directories = [
+                            "Downloads"
+                          ];
+                        };
+                      }
+                    '';
+
                   };
 
                   files = mkOption {


### PR DESCRIPTION
A couple of the options in these modules lack a description field. This causes documentation builds to fail with default settings (` documentation.nixos.options.warningsAreErrors` defaults to true and missing descriptions cause warnings). If you wanna see the error I’m seeing, add `documentation.nixos.includeAllModules = true;` to a system configuration that includes the Impermanence module.

I also added the example to the new `users` option in the NixOS module that was in your commit message.