### PR TITLE
Add default NixOS module to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,5 +2,6 @@
   outputs = { self }: {
     nixosModules.impermanence = import ./nixos.nix;
     nixosModules.home-manager.impermanence = import ./home-manager.nix;
+    nixosModule = self.nixosModules.impermanence;
   };
 }


### PR DESCRIPTION
This adds a “default” NixOS module in `flake.nix`. This makes using this in flakes a little less verbose and repetitive.

Before this change:

```nix
nixpkgs.lib.nixosSystem {
  modules = [
    ./configuration.nix
    impermanence.nixosModules.impermanence
  ];
}
```

After this change:

```nix
nixpkgs.lib.nixosSystem {
  modules = [
    ./configuration.nix
    impermanence.nixosModule
  ];
}
```