### PR TITLE
nixos: Minimize activation script debug, add debugging, and more

### DIFF
--- a/create-directories.bash
+++ b/create-directories.bash
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 
-set -o nounset
-set -o errexit
-set -o pipefail
-set -o errtrace
+set -o nounset            # Fail on use of unset variable.
+set -o errexit            # Exit on command failure.
+set -o pipefail           # Exit on failure of any command in a pipeline.
+set -o errtrace           # Trap errors in functions and subshells.
+set -o noglob             # Disable filename expansion (globbing),
+                          # since it could otherwise happen during
+                          # path splitting.
+shopt -s inherit_errexit  # Inherit the errexit option status in subshells.
 
+# Print a useful trace when an error occurs
 trap 'echo Error when executing ${BASH_COMMAND} at line ${LINENO}! >&2' ERR
 
 # Given a source directory, /source, and a target directory,

--- a/create-directories.bash
+++ b/create-directories.bash
@@ -28,8 +28,8 @@ trap 'echo Error when executing ${BASH_COMMAND} at line ${LINENO}! >&2' ERR
 #   3. Copy the mode of the source path to the target path
 
 # Get inputs from command line arguments
-if [[ "$#" != 5 ]]; then
-    printf "Error: 'create-directories.bash' requires *five* args.\n" >&2
+if [[ "$#" != 6 ]]; then
+    printf "Error: 'create-directories.bash' requires *six* args.\n" >&2
     exit 1
 fi
 sourceBase="$1"
@@ -37,6 +37,11 @@ target="$2"
 user="$3"
 group="$4"
 mode="$5"
+debug="$6"
+
+if (( "$debug" )); then
+    set -o xtrace
+fi
 
 # trim trailing slashes the root of all evil
 sourceBase="${sourceBase%/}"
@@ -58,7 +63,7 @@ for pathPart in $target; do
 
     # skip empty parts caused by the prefix slash and multiple
     # consecutive slashes
-    [[ $pathPart == "" ]] && continue
+    [[ "$pathPart" == "" ]] && continue
 
     # construct the incremental path, e.g. /var, /var/lib, /var/lib/iwd
     currentTargetPath="$previousPath$pathPart/"

--- a/mount-file.bash
+++ b/mount-file.bash
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -o nounset            # Fail on use of unset variable.
+set -o errexit            # Exit on command failure.
+set -o pipefail           # Exit on failure of any command in a pipeline.
+set -o errtrace           # Trap errors in functions and subshells.
+shopt -s inherit_errexit  # Inherit the errexit option status in subshells.
+
+# Print a useful trace when an error occurs
+trap 'echo Error when executing ${BASH_COMMAND} at line ${LINENO}! >&2' ERR
+
+# Get inputs from command line arguments
+if [[ "$#" != 3 ]]; then
+    echo "Error: 'mount-file.bash' requires *three* args." >&2
+    exit 1
+fi
+
+mountPoint="$1"
+targetFile="$2"
+debug="$3"
+
+if (( "$debug" )); then
+    set -o xtrace
+fi
+
+if [[ -L "$mountPoint" && $(readlink -f "$mountPoint") == "$targetFile" ]]; then
+    echo "$mountPoint already links to $targetFile, ignoring"
+elif mount | grep -F "$mountPoint"' ' >/dev/null && ! mount | grep -F "$mountPoint"/ >/dev/null; then
+    echo "mount already exists at $mountPoint, ignoring"
+elif [[ -e "$mountPoint" ]]; then
+    echo "A file already exists at $mountPoint!" >&2
+    exit 1
+elif [[ -e "$targetFile" ]]; then
+    touch "$mountPoint"
+    mount -o bind "$targetFile" "$mountPoint"
+else
+    ln -s "$targetFile" "$mountPoint"
+fi

--- a/nixos.nix
+++ b/nixos.nix
@@ -305,6 +305,17 @@ in
                       Whether to hide bind mounts from showing up as mounted drives.
                     '';
                   };
+
+                  enableDebugging = mkOption {
+                    type = bool;
+                    default = false;
+                    internal = true;
+                    description = ''
+                      Enable debug trace output when running
+                      scripts. You only need to enable this if asked
+                      to.
+                    '';
+                  };
                 };
               config =
                 let
@@ -415,9 +426,20 @@ in
           patchShebangs $out
         '';
 
-        mkDirWithPerms = { directory, persistentStoragePath, user, group, mode }: ''
-          ${createDirectories} ${escapeShellArgs [persistentStoragePath directory user group mode]}
-        '';
+        mkDirWithPerms = { directory, persistentStoragePath, user, group, mode }:
+          let
+            args = [
+              persistentStoragePath
+              directory
+              user
+              group
+              mode
+              cfg.${persistentStoragePath}.enableDebugging
+            ];
+          in
+          ''
+            ${createDirectories} ${escapeShellArgs args}
+          '';
 
         # Build an activation script which creates all persistent
         # storage directories we want to bind mount.

--- a/nixos.nix
+++ b/nixos.nix
@@ -15,20 +15,9 @@ let
   allPersistentStoragePaths = { directories = [ ]; files = [ ]; users = [ ]; }
     // (zipAttrsWith (_name: flatten) (attrValues cfg));
   inherit (allPersistentStoragePaths) files directories;
-  mkMountScript = mountPoint: targetFile: ''
-    if [[ -L ${mountPoint} && $(readlink -f ${mountPoint}) == ${targetFile} ]]; then
-        echo "${mountPoint} already links to ${targetFile}, ignoring"
-    elif mount | grep -F ${mountPoint}' ' >/dev/null && ! mount | grep -F ${mountPoint}/ >/dev/null; then
-        echo "mount already exists at ${mountPoint}, ignoring"
-    elif [[ -e ${mountPoint} ]]; then
-        echo "A file already exists at ${mountPoint}!" >&2
-        exit 1
-    elif [[ -e ${targetFile} ]]; then
-        touch ${mountPoint}
-        mount -o bind ${targetFile} ${mountPoint}
-    else
-        ln -s ${targetFile} ${mountPoint}
-    fi
+  mountFile = pkgs.runCommand "impermanence-mount-file" { } ''
+    cp ${./mount-file.bash} $out
+    patchShebangs $out
   '';
 in
 {
@@ -368,6 +357,7 @@ in
           let
             targetFile = escapeShellArg (concatPaths [ persistentStoragePath file ]);
             mountPoint = escapeShellArg file;
+            enableDebugging = escapeShellArg cfg.${persistentStoragePath}.enableDebugging;
           in
           {
             "persist-${sanitizeName targetFile}" = {
@@ -379,10 +369,7 @@ in
               serviceConfig = {
                 Type = "oneshot";
                 RemainAfterExit = true;
-                ExecStart = pkgs.writeShellScript "bindOrLink-${sanitizeName targetFile}" ''
-                  set -eu
-                  ${mkMountScript mountPoint targetFile}
-                '';
+                ExecStart = "${mountFile} ${mountPoint} ${targetFile} ${enableDebugging}";
                 ExecStop = pkgs.writeShellScript "unbindOrUnlink-${sanitizeName targetFile}" ''
                   set -eu
                   if [[ -L ${mountPoint} ]]; then
@@ -443,7 +430,7 @@ in
 
         # Build an activation script which creates all persistent
         # storage directories we want to bind mount.
-        dirCreationScripts =
+        dirCreationScript =
           let
             inherit directories;
             fileDirectories = unique (map
@@ -454,29 +441,45 @@ in
                 } // f.parentDirectory)
               files);
           in
-          {
-            "createPersistentStorageDirs" = {
-              deps = [ "users" "groups" ];
-              text = concatMapStrings mkDirWithPerms (directories ++ fileDirectories);
-            };
-          };
+          pkgs.writeShellScript "impermanence-run-create-directories" ''
+            _status=0
+            trap "_status=1" ERR
+            ${concatMapStrings mkDirWithPerms (directories ++ fileDirectories)}
+            exit $_status
+          '';
 
-        persistFileScript = { file, persistentStoragePath, ... }:
+        mkPersistFile = { file, persistentStoragePath, ... }:
           let
-            targetFile = escapeShellArg (concatPaths [ persistentStoragePath file ]);
-            mountPoint = escapeShellArg file;
+            mountPoint = file;
+            targetFile = concatPaths [ persistentStoragePath file ];
+            args = escapeShellArgs [
+              mountPoint
+              targetFile
+              cfg.${persistentStoragePath}.enableDebugging
+            ];
           in
-          {
-            "persist-${sanitizeName targetFile}" = {
-              deps = [ "createPersistentStorageDirs" ];
-              text = mkMountScript mountPoint targetFile;
-            };
-          };
+          ''
+            ${mountFile} ${args}
+          '';
 
-        persistFileScripts =
-          foldl' recursiveUpdate { } (map persistFileScript files);
+        persistFileScript =
+          pkgs.writeShellScript "impermanence-persist-files" ''
+            _status=0
+            trap "_status=1" ERR
+            ${concatMapStrings mkPersistFile files}
+            exit $_status
+          '';
       in
-      dirCreationScripts // persistFileScripts;
+      {
+        "createPersistentStorageDirs" = {
+          deps = [ "users" "groups" ];
+          text = "${dirCreationScript}";
+        };
+        "persist-files" = {
+          deps = [ "createPersistentStorageDirs" ];
+          text = "${persistFileScript}";
+        };
+      };
 
     assertions =
       let


### PR DESCRIPTION
### nixos: Minimize the amount of text added to the activation script

This is done to reduce the risk of build errors, isolate each run of the script and reduce the amount of replicated code.

- Make the file mount script generated by `mkMountScript` a discrete script and only generate its invocations.

- Wrap the script invocations in scripts.

Fixes #77, #78

### nixos: Add an internal debugging option to aid script debugging

This should let users provide detailed traces of script errors.

### create-directories: Set noglob and inherit_errexit, document options

In addition to the currently set bash options, set `noglob` and `inherit_errexit`.

- `noglob` disables filename expansion, which could happen in the for loop where we do path splitting if the path contains characters recognized by bash as wildcards, such as `?` or `*`.

- `inherit_errexit` makes subshells inherit the status of the `errexit` option.
