### PR TITLE
Add `force` option for replacing existing files

### DIFF
--- a/README.org
+++ b/README.org
@@ -46,6 +46,7 @@
           files = [
             "/etc/machine-id"
             { file = "/etc/nix/id_rsa"; parentDirectory = { mode = "u=rwx,g=,o="; }; }
+            { file = "/etc/shadow"; force = true; }; }
           ];
           users.talyz = {
             directories = [

--- a/nixos.nix
+++ b/nixos.nix
@@ -352,6 +352,7 @@ in
             files = [
               "/etc/machine-id"
               { file = "/etc/nix/id_rsa"; parentDirectory = { mode = "u=rwx,g=,o="; }; }
+              { file = "/etc/shadow"; force = true; }; }
             ];
           };
           users.talyz = { ... }; # See the dedicated example


### PR DESCRIPTION
I wrote this in hopes that I could manage `/etc/shadow` with impermanence. Unfortunately, this does not play along with the `rename`-based atomic update mechanism applied by both `passwd` and nixos's `update-users-groups.pl`, so I don't have a good example to use in the documentation...