### PR TITLE
home-manager: adds configurable symlink/bindfs option

### DIFF
--- a/README.org
+++ b/README.org
@@ -199,6 +199,10 @@
             ".nixops"
             ".local/share/keyrings"
             ".local/share/direnv"
+            {
+              directory = ".local/share/Steam";
+              method = "symlink";
+            }
           ];
           files = [
             ".screenrc"
@@ -210,7 +214,10 @@
 
     - ~"/persistent/home/talyz"~ is the path to your persistent storage location
     - ~directories~ are all directories you want to link to persistent storage
-    - ~files~ are all files you want to link to persistent storage
+        - It is possible to switch the linking ~method~ between bindfs (the
+          default) and symbolic links.
+    - ~files~ are all files you want to link to persistent storage. These are
+      symbolic links to their target location.
     - ~allowOther~ allows other users, such as ~root~, to access files
       through the bind mounted directories listed in
       ~directories~. Useful for ~sudo~ operations, Docker, etc. Requires
@@ -240,9 +247,9 @@
     removes the first part of the path when deciding where to put the
     links.
 
-    /Note:/ Since this module uses the ~bindfs~ fuse filesystem for
-    directories, the names of the directories you add will be visible
-    in the ~/etc/mtab~ file and in the output of ~mount~ to all users.
+    /Note:/ When using ~bindfs~ fuse filesystem for directories, the names of
+    the directories you add will be visible in the ~/etc/mtab~ file and in the
+    output of ~mount~ to all users.
 
 ** Further reading
    The following blog posts provide more information on the concept of ephemeral


### PR DESCRIPTION
Hello, all! A huge thanks to the maintainers :), I've been using impermanence for a while and really love it.

---

As mentioned in https://github.com/nix-community/impermanence/issues/42, bindfs causes some issues with a few specific programs (steam, for example). I'm aware that we have options for using the NixOS module to avoid bindfs, but that may not be preferred (or possible) for some.

This PR allows for setting a specific `method` for each individual directory. They can (atm) be either "bindfs" (the default if not specified) or "symlink".

I've reused the code that links files, but now it runs on `directories` that have `method = "symlink"` as well.


I made sure that changing between the two methods works reliably. For that end, I've added:
- a `cleanEmptyLinkTargets` activation script that handles changing from bindfs to symlink. If a link's intended location has something mounted, it is unmounted (earlier than usual) and its mount point is deleted (safely with `rm -d`).
- a `mount | grep` condition on the usual unmount phase, to avoid systemd trying to unmount a symlink (causes error messagens and a few seconds of hanging, although it ultimately works).

~Oh, and by the way, git got a little confused with the repeated unmount code and messed up the diff. The only change I made to `mkUnmount` was adding the `mount | grep` check.~

As we have three places with the same unmount code now, I've factored it out to a function. Diff looks fine now.


Hope this is useful, and please let me know if there's anything to be improved!

---
Fixes #42 