### PR TITLE
Make bash scripts work in cross-compiled environments.

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -15,7 +15,7 @@ let
   allPersistentStoragePaths = { directories = [ ]; files = [ ]; users = [ ]; }
     // (zipAttrsWith (_name: flatten) (attrValues cfg));
   inherit (allPersistentStoragePaths) files directories;
-  mountFile = pkgs.runCommand "impermanence-mount-file" { } ''
+  mountFile = pkgs.runCommand "impermanence-mount-file" { buildInputs = [ pkgs.bash ]; } ''
     cp ${./mount-file.bash} $out
     patchShebangs $out
   '';
@@ -412,7 +412,7 @@ in
         # Script to create directories in persistent and ephemeral
         # storage. The directory structure's mode and ownership mirror
         # those of persistentStoragePath/dir.
-        createDirectories = pkgs.runCommand "impermanence-create-directories" { } ''
+        createDirectories = pkgs.runCommand "impermanence-create-directories" { buildInputs = [ pkgs.bash ]; } ''
           cp ${./create-directories.bash} $out
           patchShebangs $out
         '';


### PR DESCRIPTION
When cross-compiling, `patchShebangs` requires the host platform's bash
to be present in the HOST_PATH environment variable. However, when
using `pkgs.runCommand`, only the build platform's bash is added to the
PATH. The result is that the shebang is not replaced, and the script
fails to run because the activation scripts don't have `bash` in their
environment.

Using an explicit `mkDerivation` lets us add the host bash as a
`buildInput`, which makes `patchShebangs` work as expected.

For context, I'm using impermanence on a Raspberry Pi 0. Since no
binary cache exists for that platform, I cross-compile the entire OS and
configuration from an x86_64 host and only push the resulting closure.