### PR TITLE
Remove /etc/nix/id_rsa from example

### DIFF
--- a/README.org
+++ b/README.org
@@ -45,7 +45,6 @@
           ];
           files = [
             "/etc/machine-id"
-            { file = "/etc/nix/id_rsa"; parentDirectory = { mode = "u=rwx,g=,o="; }; }
           ];
           users.talyz = {
             directories = [

--- a/nixos.nix
+++ b/nixos.nix
@@ -263,7 +263,6 @@ in
                     default = [ ];
                     example = [
                       "/etc/machine-id"
-                      "/etc/nix/id_rsa"
                     ];
                     description = ''
                       Files that should be stored in persistent storage.
@@ -355,7 +354,6 @@ in
             ];
             files = [
               "/etc/machine-id"
-              { file = "/etc/nix/id_rsa"; parentDirectory = { mode = "u=rwx,g=,o="; }; }
             ];
           };
           users.talyz = { ... }; # See the dedicated example


### PR DESCRIPTION
I couldn't find any mention of this file except sources related with this repository. Furthermore the example changes the permissions of the `/etc/nix` directory. This breaks the new nix command for non-root users because the nix config file isn't readable anymore.