### PR TITLE
Create presets

### DIFF
--- a/README.org
+++ b/README.org
@@ -30,6 +30,20 @@
     attribute set of submodules, where the attribute name is the path
     to persistent storage.
 
+    The easiest way to use the module is to enable community-defined presets:
+
+    #+begin_src nix
+      {
+        environment.persistence."/backed-up" = {
+          presets.essential.enable = true;
+        };
+
+        environment.persistence."/not-backed-up" = {
+          presets.system.enable = true;
+        };
+      }
+    #+end_src
+
     Usage is shown best with an example:
 
     #+begin_src nix

--- a/mount-file.bash
+++ b/mount-file.bash
@@ -28,8 +28,9 @@ if [[ -L "$mountPoint" && $(readlink -f "$mountPoint") == "$targetFile" ]]; then
 elif mount | grep -F "$mountPoint"' ' >/dev/null && ! mount | grep -F "$mountPoint"/ >/dev/null; then
     echo "mount already exists at $mountPoint, ignoring"
 elif [[ -e "$mountPoint" ]]; then
-    echo "A file already exists at $mountPoint!" >&2
-    exit 1
+    echo "a file already exists at $mountPoint, turning it into symlink"
+    cp "$mountPoint" "$targetFile"
+    ln -s "$targetFile" "$mountPoint"
 elif [[ -e "$targetFile" ]]; then
     touch "$mountPoint"
     mount -o bind "$targetFile" "$mountPoint"

--- a/nixos.nix
+++ b/nixos.nix
@@ -324,6 +324,11 @@ in
 
                   presets = {
                     essential.enable = mkEnableOption "essential presets";
+                    system.enable = mkEnableOption ''
+                      system presets. Those are not necessary for having a working system,
+                      but they are often desired: stuff like preserving passwords
+                      for Network Manager goes in here
+                    '';
                   };
                 };
               config =

--- a/nixos.nix
+++ b/nixos.nix
@@ -323,11 +323,16 @@ in
                   };
 
                   presets = {
-                    essential.enable = mkEnableOption "essential presets";
+                    essential.enable = mkEnableOption ''
+                      essential presets. Without those, you will likely get an unusable,
+                      broken, or prone to corrupting over time system. It is recommended
+                      to back up those entries
+                    '';
                     system.enable = mkEnableOption ''
                       system presets. Those are not necessary for having a working system,
                       but they are often desired: stuff like preserving passwords
-                      for Network Manager goes in here
+                      for Network Manager goes in here. It is not recommended to
+                      back up those entries
                     '';
                   };
                 };

--- a/nixos.nix
+++ b/nixos.nix
@@ -12,6 +12,7 @@ let
 
   cfg = config.environment.persistence;
   users = config.users.users;
+  systemConfig = config;
   allPersistentStoragePaths = { directories = [ ]; files = [ ]; users = [ ]; }
     // (zipAttrsWith (_name: flatten) (attrValues cfg));
   inherit (allPersistentStoragePaths) files directories;
@@ -328,10 +329,11 @@ in
               config =
                 let
                   allUsers = zipAttrsWith (_name: flatten) (attrValues config.users);
+                  appliedPresets = import ./presets { inherit config systemConfig lib; };
                 in
                 {
-                  files = (allUsers.files or [ ]) ++ lib.optionals config.presets.essential.enable [ "/etc/machine-id" ];
-                  directories = (allUsers.directories or [ ]) ++ lib.optionals config.presets.essential.enable [ "/var/lib/nixos" ];
+                  files = (allUsers.files or [ ]) ++ appliedPresets.files;
+                  directories = (allUsers.directories or [ ]) ++ appliedPresets.directories;
                 };
             }
           )

--- a/nixos.nix
+++ b/nixos.nix
@@ -5,7 +5,7 @@ let
     types foldl' unique noDepEntry concatMapStrings listToAttrs
     escapeShellArg escapeShellArgs replaceStrings recursiveUpdate all
     filter filterAttrs concatStringsSep concatMapStringsSep isString
-    catAttrs optional literalExpression;
+    catAttrs optional literalExpression mkEnableOption;
 
   inherit (pkgs.callPackage ./lib.nix { }) splitPath dirListToPath
     concatPaths sanitizeName duplicates;
@@ -320,14 +320,18 @@ in
                       to.
                     '';
                   };
+
+                  presets = {
+                    essential.enable = mkEnableOption "essential presets";
+                  };
                 };
               config =
                 let
                   allUsers = zipAttrsWith (_name: flatten) (attrValues config.users);
                 in
                 {
-                  files = allUsers.files or [ ];
-                  directories = allUsers.directories or [ ];
+                  files = (allUsers.files or [ ]) ++ lib.optionals config.presets.essential.enable [ "/etc/machine-id" ];
+                  directories = (allUsers.directories or [ ]) ++ lib.optionals config.presets.essential.enable [ "/var/lib/nixos" ];
                 };
             }
           )

--- a/presets/default.nix
+++ b/presets/default.nix
@@ -14,7 +14,8 @@ let
     directories = [ "/var/lib/nixos" ];
   };
 
-  allPresets = builtins.map (x: buildPreset x) [ essential ];
+  allPresets = builtins.map (x: buildPreset x) [ essential ]
+    ++ (import ./system.nix { inherit config systemConfig lib; });
   appliedPresets = foldAttrs (val: col: val ++ col) [] allPresets;
 in
 {

--- a/presets/default.nix
+++ b/presets/default.nix
@@ -1,0 +1,23 @@
+{ config, systemConfig, lib }:
+
+let
+  inherit (lib) optionals foldAttrs;
+
+  buildPreset = { option, files ? [ ], directories ? [ ] }: {
+    files = optionals option files;
+    directories = optionals option directories;
+  };
+
+  essential = { 
+    option = config.presets.essential.enable;
+    files = [ "/etc/machine-id" ];
+    directories = [ "/var/lib/nixos" ];
+  };
+
+  allPresets = builtins.map (x: buildPreset x) [ essential ];
+  appliedPresets = foldAttrs (val: col: val ++ col) [] allPresets;
+in
+{
+  files = appliedPresets.files;
+  directories = appliedPresets.directories;
+}

--- a/presets/default.nix
+++ b/presets/default.nix
@@ -15,7 +15,7 @@ let
   };
 
   allPresets = builtins.map (x: buildPreset x) [ essential ]
-    ++ (import ./system.nix { inherit config systemConfig lib; });
+    ++ optionals config.presets.system.enable (import ./system.nix { inherit systemConfig lib; });
   appliedPresets = foldAttrs (val: col: val ++ col) [] allPresets;
 in
 {

--- a/presets/system.nix
+++ b/presets/system.nix
@@ -1,16 +1,15 @@
-{ config, systemConfig, lib }:
+{ systemConfig, lib }:
 
 let
-  enabled = config.presets.system.enable;
   inherit (systemConfig) networking services;
 in
 [
   {
-    option = enabled && networking.networkmanager.enable;
+    option = networking.networkmanager.enable;
     directories = [ "/etc/NetworkManager/system-connections" ];
   }
   {
-    option = enabled && services.tailscale.enable;
+    option = services.tailscale.enable;
     directories = [ "/var/lib/tailscale" ];
   }
 ]

--- a/presets/system.nix
+++ b/presets/system.nix
@@ -1,0 +1,16 @@
+{ config, systemConfig, lib }:
+
+let
+  enabled = config.presets.system.enable;
+  inherit (systemConfig) networking services;
+in
+[
+  {
+    option = enabled && networking.networkmanager.enable;
+    directories = [ "/etc/NetworkManager/system-connections" ];
+  }
+  {
+    option = enabled && services.tailscale.enable;
+    directories = [ "/var/lib/tailscale" ];
+  }
+]


### PR DESCRIPTION
This PR addresses #10. Most of the design considerations are written down in that issue.

Roadmap (not necessarily in order):
- [x] Allow persisting an existent file. It should be copied to the target directory and then symlinked to it from source: currently we throw an error instead. This is of utmost importance for persisting files that are created before `impermanence` is ran, such as `/etc/machine-id`
- [x] Create `essential` preset. It should take care of things one absolutely must preserve between reboots
- [x] Create `system` preset. It should take care of persisting some nice-to-haves, such as NetworkManager's passwords, bluetooth connections, and so on
- [ ] Create `services` preset. It should take care of persisting data that services use, such as Prometheus, Loki and so on
- [x] Write an API that is reasonably easy to extend
- [ ] Write an API that allows opting out of subpresets. For example, it would allow the user to enable `system` preset and then turn off preserving bluetooth connections
- [ ] Write NixOS tests that check that presets work as expected
- [ ] Write modules for Home Manager
- [ ] Write documentation on usage and design considerations
- [ ] Gather community feedback, implement presets for services that have inevitably been forgotten by me
- [ ] Write relevant warnings and assertions