### PR TITLE
nixos: Improve directory creation and permission and ownership assignment

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,4 +1,4 @@
-* Impermanence
+#+TITLE: Impermanence
 
   Modules to help you handle persistent state on systems with
   ephemeral root storage.
@@ -13,6 +13,13 @@
   3. want to create links from temporary storage to persistent
      storage, so that specified files and folders persist between
      reboots
+
+
+* Contact
+
+  Join the [[https://matrix.to/#/#impermanence:nixos.org][matrix room]] to chat about the project.
+
+* Usage
 
   There are currently two modules: one for ~NixOS~ and one for ~home-manager~.
 
@@ -261,9 +268,3 @@
    - https://grahamc.com/blog/erase-your-darlings --- [[https://github.com/grahamc/][@grahamc]]'s blog post details
      why one would want to erase their state at every boot, as well as how to
      achieve this using ZFS snapshots.
-
-** About the name
-   : Impermanence, also known as the philosophical problem of change, is a
-   : philosophical concept that is addressed in a variety of religions and
-   : philosophies. In Eastern philosophy it is best known for its role in the
-   : Buddhist three marks of existence. It also is an element of Hinduism.

--- a/README.org
+++ b/README.org
@@ -109,10 +109,10 @@
       - ~mode~, the permissions to set for the directory. If the
         directory doesn't already exist in persistent storage, it will
         be created with this mode. Can be either an octal mode
-        (e.g. ~0700~) or a symbolic mode (e.g. ~u=rwx,g=,o=~). This also
-        applies to any parent directories which don't yet exist.
-        Changing this once the directory has been created has no
-        effect.
+        (e.g. ~0700~) or a symbolic mode (e.g. ~u=rwx,g=,o=~). Parent
+        directories that don't yet exist are created with default
+        permissions. Changing this once the directory has been created
+        has no effect.
 
     - ~files~ are all files you want to link or bind to persistent
       storage. A file can be represented either as a string, simply

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -11,7 +11,12 @@ let
   isBindfs = v: (getDirMethod v) == "bindfs";
   isSymlink = v: (getDirMethod v) == "symlink";
 
-  inherit (pkgs.callPackage ./lib.nix { }) splitPath dirListToPath concatPaths sanitizeName;
+  inherit (pkgs.callPackage ./lib.nix { })
+    splitPath
+    dirListToPath
+    concatPaths
+    sanitizeName
+    ;
 
   mount = "${pkgs.util-linux}/bin/mount";
   unmountScript = mountPoint: tries: sleep: ''

--- a/lib.nix
+++ b/lib.nix
@@ -11,6 +11,9 @@ let
     removePrefix
     foldl'
     elem
+    take
+    length
+    last
     ;
   inherit (lib.strings)
     sanitizeDerivationName
@@ -33,6 +36,24 @@ let
       path = dirListToPath (splitPath paths);
     in
     prefix + path;
+
+
+  parentsOf = path:
+    let
+      prefix = optionalString (hasPrefix "/" path) "/";
+      split = splitPath [ path ];
+      parents = take ((length split) - 1) split;
+    in
+    foldl'
+      (state: item:
+        state ++ [
+          (concatPaths [
+            (if state != [ ] then last state else prefix)
+            item
+          ])
+        ])
+      [ ]
+      parents;
 
   sanitizeName = name:
     replaceStrings
@@ -63,6 +84,7 @@ in
     splitPath
     dirListToPath
     concatPaths
+    parentsOf
     sanitizeName
     duplicates
     ;

--- a/lib.nix
+++ b/lib.nix
@@ -1,8 +1,20 @@
 { lib }:
 let
-  inherit (lib) filter concatMap concatStringsSep hasPrefix head
-    replaceStrings optionalString removePrefix foldl' elem;
-  inherit (lib.strings) sanitizeDerivationName;
+  inherit (lib)
+    filter
+    concatMap
+    concatStringsSep
+    hasPrefix
+    head
+    replaceStrings
+    optionalString
+    removePrefix
+    foldl'
+    elem
+    ;
+  inherit (lib.strings)
+    sanitizeDerivationName
+    ;
 
   # ["/home/user/" "/.screenrc"] -> ["home" "user" ".screenrc"]
   splitPath = paths:
@@ -47,5 +59,11 @@ let
     result.duplicates;
 in
 {
-  inherit splitPath dirListToPath concatPaths sanitizeName duplicates;
+  inherit
+    splitPath
+    dirListToPath
+    concatPaths
+    sanitizeName
+    duplicates
+    ;
 }

--- a/nixos.nix
+++ b/nixos.nix
@@ -205,7 +205,7 @@ in
                                 '';
                               };
                               files = mkOption {
-                                type = listOf (either str userFile);
+                                type = listOf (coercedTo str (f: { file = f; }) userFile);
                                 default = [ ];
                                 example = [
                                   ".screenrc"
@@ -214,22 +214,10 @@ in
                                   Files that should be stored in
                                   persistent storage.
                                 '';
-                                apply =
-                                  map (file:
-                                    if isString file then
-                                      {
-                                        inherit persistentStoragePath;
-                                        file = concatPaths [ config.home file ];
-                                        parentDirectory = userDefaultPerms;
-                                      }
-                                    else
-                                      file // {
-                                        file = concatPaths [ config.home file.file ];
-                                      });
                               };
 
                               directories = mkOption {
-                                type = listOf (either str userDir);
+                                type = listOf (coercedTo str (d: { directory = d; }) userDir);
                                 default = [ ];
                                 example = [
                                   "Downloads"
@@ -242,17 +230,6 @@ in
                                   Directories to bind mount to
                                   persistent storage.
                                 '';
-                                apply =
-                                  map (directory:
-                                    if isString directory then
-                                      userDefaultPerms // {
-                                        directory = concatPaths [ config.home directory ];
-                                        inherit persistentStoragePath;
-                                      }
-                                    else
-                                      directory // {
-                                        directory = concatPaths [ config.home directory.directory ];
-                                      });
                               };
                             };
                         }
@@ -295,7 +272,7 @@ in
                   };
 
                   files = mkOption {
-                    type = listOf (either str rootFile);
+                    type = listOf (coercedTo str (f: { file = f; }) rootFile);
                     default = [ ];
                     example = [
                       "/etc/machine-id"
@@ -304,19 +281,10 @@ in
                     description = ''
                       Files that should be stored in persistent storage.
                     '';
-                    apply =
-                      map (file:
-                        if isString file then
-                          {
-                            inherit file persistentStoragePath;
-                            parentDirectory = defaultPerms;
-                          }
-                        else
-                          file);
                   };
 
                   directories = mkOption {
-                    type = listOf (either str rootDir);
+                    type = listOf (coercedTo str (d: { directory = d; }) rootDir);
                     default = [ ];
                     example = [
                       "/var/log"
@@ -328,14 +296,6 @@ in
                     description = ''
                       Directories to bind mount to persistent storage.
                     '';
-                    apply =
-                      map (directory:
-                        if isString directory then
-                          defaultPerms // {
-                            inherit directory persistentStoragePath;
-                          }
-                        else
-                          directory);
                   };
 
                   hideMounts = mkOption {

--- a/nixos.nix
+++ b/nixos.nix
@@ -1,14 +1,40 @@
 { pkgs, config, lib, ... }:
 
 let
-  inherit (lib) attrNames attrValues zipAttrsWith flatten mkOption
-    mkDefault mapAttrsToList types foldl' unique concatMapStrings
-    listToAttrs escapeShellArg escapeShellArgs recursiveUpdate all
-    filter filterAttrs concatStringsSep concatMapStringsSep isString
-    catAttrs optional literalExpression;
+  inherit (lib)
+    attrNames
+    attrValues
+    zipAttrsWith
+    flatten
+    mkOption
+    mkDefault
+    mapAttrsToList
+    types
+    foldl'
+    unique
+    concatMapStrings
+    listToAttrs
+    escapeShellArg
+    escapeShellArgs
+    recursiveUpdate
+    all
+    filter
+    filterAttrs
+    concatStringsSep
+    concatMapStringsSep
+    isString
+    catAttrs
+    optional
+    literalExpression
+    ;
 
-  inherit (pkgs.callPackage ./lib.nix { }) splitPath dirListToPath
-    concatPaths sanitizeName duplicates;
+  inherit (pkgs.callPackage ./lib.nix { })
+    splitPath
+    dirListToPath
+    concatPaths
+    sanitizeName
+    duplicates
+    ;
 
   cfg = config.environment.persistence;
   users = config.users.users;
@@ -43,7 +69,17 @@ in
       default = { };
       type =
         let
-          inherit (types) attrsOf bool listOf submodule path either str;
+          inherit (types)
+            attrsOf
+            bool
+            listOf
+            submodule
+            nullOr
+            path
+            either
+            str
+            coercedTo
+            ;
         in
         attrsOf (
           submodule (

--- a/nixos.nix
+++ b/nixos.nix
@@ -47,10 +47,10 @@ let
   '';
 
   # Create fileSystems bind mount entry.
-  mkBindMountNameValuePair = { directory, persistentStoragePath, ... }: {
-    name = concatPaths [ "/" directory ];
+  mkBindMountNameValuePair = { dirPath, persistentStoragePath, ... }: {
+    name = concatPaths [ "/" dirPath ];
     value = {
-      device = concatPaths [ persistentStoragePath directory ];
+      device = concatPaths [ persistentStoragePath dirPath ];
       noCheck = true;
       options = [ "bind" ]
         ++ optional cfg.${persistentStoragePath}.hideMounts "x-gvfs-hide";
@@ -101,6 +101,15 @@ in
                       file should be stored.
                     '';
                   };
+                  home = mkOption {
+                    type = nullOr path;
+                    default = null;
+                    internal = true;
+                    description = ''
+                      The path to the home directory the file is
+                      placed within.
+                    '';
+                  };
                 };
               };
               dirPermsOpts = {
@@ -139,6 +148,10 @@ in
                     '';
                   };
                   parentDirectory = dirPermsOpts;
+                  filePath = mkOption {
+                    type = path;
+                    internal = true;
+                  };
                 };
               };
               dirOpts = {
@@ -149,16 +162,26 @@ in
                       The path to the directory.
                     '';
                   };
+                  dirPath = mkOption {
+                    type = path;
+                    internal = true;
+                  };
                 } // dirPermsOpts;
               };
               rootFile = submodule [
                 commonOpts
                 fileOpts
-                { parentDirectory = mkDefault defaultPerms; }
+                ({ config, ... }: {
+                  parentDirectory = mkDefault defaultPerms;
+                  filePath = mkDefault config.file;
+                })
               ];
               rootDir = submodule ([
                 commonOpts
                 dirOpts
+                ({ config, ... }: {
+                  dirPath = mkDefault config.directory;
+                })
               ] ++ (mapAttrsToList (n: v: { ${n} = mkDefault v; }) defaultPerms));
             in
             {
@@ -174,14 +197,36 @@ in
                             user = name;
                             group = users.${userDefaultPerms.user}.group;
                           };
+                          fileConfig =
+                            { config, ... }:
+                            {
+                              filePath =
+                                if config.home != null then
+                                  concatPaths [ config.home config.file ]
+                                else
+                                  config.file;
+                            };
                           userFile = submodule [
                             commonOpts
                             fileOpts
                             { parentDirectory = mkDefault userDefaultPerms; }
+                            { inherit (config) home; }
+                            fileConfig
                           ];
+                          dirConfig =
+                            { config, ... }:
+                            {
+                              dirPath =
+                                if config.home != null then
+                                  concatPaths [ config.home config.directory ]
+                                else
+                                  config.directory;
+                            };
                           userDir = submodule ([
                             commonOpts
                             dirOpts
+                            { inherit (config) home; }
+                            dirConfig
                           ] ++ (mapAttrsToList (n: v: { ${n} = mkDefault v; }) userDefaultPerms));
                         in
                         {
@@ -204,6 +249,7 @@ in
                                   nixpkgs.
                                 '';
                               };
+
                               files = mkOption {
                                 type = listOf (coercedTo str (f: { file = f; }) userFile);
                                 default = [ ];
@@ -369,10 +415,10 @@ in
   config = {
     systemd.services =
       let
-        mkPersistFileService = { file, persistentStoragePath, ... }:
+        mkPersistFileService = { filePath, persistentStoragePath, ... }:
           let
-            targetFile = escapeShellArg (concatPaths [ persistentStoragePath file ]);
-            mountPoint = escapeShellArg file;
+            targetFile = escapeShellArg (concatPaths [ persistentStoragePath filePath ]);
+            mountPoint = escapeShellArg filePath;
             enableDebugging = escapeShellArg cfg.${persistentStoragePath}.enableDebugging;
           in
           {
@@ -415,11 +461,11 @@ in
           patchShebangs $out
         '';
 
-        mkDirWithPerms = { directory, persistentStoragePath, user, group, mode }:
+        mkDirWithPerms = { dirPath, persistentStoragePath, user, group, mode, ... }:
           let
             args = [
               persistentStoragePath
-              directory
+              dirPath
               user
               group
               mode
@@ -434,12 +480,16 @@ in
         # storage directories we want to bind mount.
         dirCreationScript =
           let
-            inherit directories;
             fileDirectories = unique (map
               (f:
-                {
+                rec {
                   directory = dirOf f.file;
-                  inherit (f) persistentStoragePath;
+                  dirPath =
+                    if f.home != null then
+                      concatPaths [ f.home directory ]
+                    else
+                      directory;
+                  inherit (f) persistentStoragePath home;
                 } // f.parentDirectory)
               files);
           in
@@ -450,10 +500,10 @@ in
             exit $_status
           '';
 
-        mkPersistFile = { file, persistentStoragePath, ... }:
+        mkPersistFile = { filePath, persistentStoragePath, ... }:
           let
-            mountPoint = file;
-            targetFile = concatPaths [ persistentStoragePath file ];
+            mountPoint = filePath;
+            targetFile = concatPaths [ persistentStoragePath filePath ];
             args = escapeShellArgs [
               mountPoint
               targetFile


### PR DESCRIPTION
Construct directory items for all parent directories of the user specified files and directories, assigning better default permissions
and ownership to each and removing this responsibility from the create-directories script.

This means that all parent directories of root directories will now have the default permissions and ownership, not inherit them from the child. User directories are assigned default user ownership. The home directory itself is handled specially to make sure it is owned by the user, not readable by anyone else and its parent gets default root ownership.

To illustrate this with an example, here is a directory specification and the ownership and permissions that could potentially be assigned to the parent directories, given none of them yet exist in persistent storage:

```nix
{
  environment.persistence."/persistent" = {
    users.talyz = {
      directories = [
        { directory = ".local/share/secret"; mode = "0500"; }
      ];
    };
  };
}
```

#### Before
```
/home                            talyz:talyz   0500
/home/talyz                      talyz:talyz   0500
/home/talyz/.local               talyz:talyz   0500
/home/talyz/.local/share         talyz:talyz   0500
/home/talyz/.local/share/secret  talyz:talyz   0500
```

#### After
```
/home                            root:root     0755
/home/talyz                      talyz:talyz   0700
/home/talyz/.local               talyz:talyz   0755
/home/talyz/.local/share         talyz:talyz   0755
/home/talyz/.local/share/secret  talyz:talyz   0500
```

Also:
- use the `coercedTo` type to convert from strings to file / directory items
- change the internal semantics of `file` and `directory`, introducing the `filePath`, `directoryPath` and `home` internal options
- formatting fixes

cc @tomeon