### PR TITLE
mount-file.bash: be quieter when debugging is off

### DIFF
--- a/mount-file.bash
+++ b/mount-file.bash
@@ -19,14 +19,19 @@ mountPoint="$1"
 targetFile="$2"
 debug="$3"
 
+trace() {
+    if (( "$debug" )); then
+      echo "$@"
+    fi
+}
 if (( "$debug" )); then
     set -o xtrace
 fi
 
 if [[ -L "$mountPoint" && $(readlink -f "$mountPoint") == "$targetFile" ]]; then
-    echo "$mountPoint already links to $targetFile, ignoring"
+    trace "$mountPoint already links to $targetFile, ignoring"
 elif mount | grep -F "$mountPoint"' ' >/dev/null && ! mount | grep -F "$mountPoint"/ >/dev/null; then
-    echo "mount already exists at $mountPoint, ignoring"
+    trace "mount already exists at $mountPoint, ignoring"
 elif [[ -e "$mountPoint" ]]; then
     echo "A file already exists at $mountPoint!" >&2
     exit 1


### PR DESCRIPTION
Tested quickly on NixOS only with [this](https://github.com/ckiee/nixfiles/blob/f4b4002bd53070c625f11b49e1ad23a078c55ee9/modules/imperm.nix) config. 

Seems to work fine I think; for some reason the service output only sometimes got in my deploy log.