### PR TITLE
nixos: Recommend persisting /var/lib/nixos

### DIFF
--- a/README.org
+++ b/README.org
@@ -39,6 +39,7 @@
           directories = [
             "/var/log"
             "/var/lib/bluetooth"
+            "/var/lib/nixos"
             "/var/lib/systemd/coredump"
             "/etc/NetworkManager/system-connections"
             { directory = "/var/lib/colord"; user = "colord"; group = "colord"; mode = "u=rwx,g=rx,o="; }

--- a/nixos.nix
+++ b/nixos.nix
@@ -285,6 +285,7 @@ in
                     example = [
                       "/var/log"
                       "/var/lib/bluetooth"
+                      "/var/lib/nixos"
                       "/var/lib/systemd/coredump"
                       "/etc/NetworkManager/system-connections"
                     ];
@@ -349,6 +350,7 @@ in
             directories = [
               "/var/log"
               "/var/lib/bluetooth"
+              "/var/lib/nixos"
               "/var/lib/systemd/coredump"
               "/etc/NetworkManager/system-connections"
               { directory = "/var/lib/colord"; user = "colord"; group = "colord"; mode = "u=rwx,g=rx,o="; }


### PR DESCRIPTION
The `/var/lib/nixos` directory contains the uid and gid map for entities without a static id. Not persisting them means your user and group ids could change between reboots, which is likely undesirable.