### PR TITLE
nixos: Mount binds after the persistent storage path

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -28,6 +28,7 @@ let
       noCheck = true;
       options = [ "bind" ]
         ++ optional cfg.${persistentStoragePath}.hideMounts "x-gvfs-hide";
+      depends = [ persistentStoragePath ];
     };
   };
 


### PR DESCRIPTION
Takes over #66 