### PR TITLE
Skip generating bind mounts if no bind mounts are configured.

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -399,7 +399,7 @@ in
 
       in
       mkMerge [
-        (mkIf (any (path: cfg.${path}.directories != [ ]) persistentStoragePaths) {
+        (mkIf (any (path: (filter isSymlink cfg.${path}.directories) != [ ]) persistentStoragePaths) {
           # Clean up existing empty directories in the way of links
           cleanEmptyLinkTargets =
             dag.entryBefore
@@ -407,7 +407,8 @@ in
               ''
                 ${concatMapStrings mkLinkCleanupForPath persistentStoragePaths}
               '';
-
+        })
+        (mkIf (any (path: (filter isBindfs cfg.${path}.directories) != [ ]) persistentStoragePaths) {
           createAndMountPersistentStoragePaths =
             dag.entryBefore
               [ "writeBoundary" ]


### PR DESCRIPTION
This fixes #105 by no longer generating an empty bash function. Empty functions in bash are invalid, which cause the activation to fail.