### PR TITLE
nixos: Fix collision detection logic

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -686,10 +686,10 @@ in
             '';
         }
         {
-          assertion = duplicates (catAttrs "file" files) == [ ];
+          assertion = duplicates (catAttrs "filePath" files) == [ ];
           message =
             let
-              offenders = duplicates (catAttrs "file" files);
+              offenders = duplicates (catAttrs "filePath" files);
             in
             ''
               environment.persistence:
@@ -699,10 +699,10 @@ in
             '';
         }
         {
-          assertion = duplicates (catAttrs "directory" directories) == [ ];
+          assertion = duplicates (catAttrs "dirPath" directories) == [ ];
           message =
             let
-              offenders = duplicates (catAttrs "directory" directories);
+              offenders = duplicates (catAttrs "dirPath" directories);
             in
             ''
               environment.persistence:


### PR DESCRIPTION
The logic for detecting whether a file or directory is specified multiple times was not updated to account for the recent file/filePath and directory/dirPath changes. This can lead to spurious failures like the following if the same home-relative path is persisted for different users:

       Failed assertions:
       - environment.persistence:
           The following directories were specified two or more
           times:
             .cache
             .config
             .local/share
             .local/state
             .gnupg
             .ssh

In addition, the assertion may falsely not trigger in the contrived situation where the same entity is persisted both in a per-user configuration (using the relative path) and the global configuration (using the absolute path).

Fix these situations by checking the absolute paths again using filePath and dirPath.