### PR TITLE
feat(nixos): allow persistant locations to be disabled

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -43,7 +43,7 @@ let
   cfg = config.environment.persistence;
   users = config.users.users;
   allPersistentStoragePaths = { directories = [ ]; files = [ ]; users = [ ]; }
-    // (zipAttrsWith (_name: flatten) (attrValues cfg));
+    // (zipAttrsWith (_name: flatten) (filter (v: v.enable) (attrValues cfg)));
   inherit (allPersistentStoragePaths) files directories;
   mountFile = pkgs.runCommand "impermanence-mount-file" { buildInputs = [ pkgs.bash ]; } ''
     cp ${./mount-file.bash} $out
@@ -201,6 +201,11 @@ in
             {
               options =
                 {
+                  enable = mkOption {
+                    type = bool;
+                    default = true;
+                    description = "Whether to enable this persistent storage location.";
+                  };
                   users = mkOption {
                     type = attrsOf (
                       submodule (


### PR DESCRIPTION
This should more easily allow specific persistence locations to be disabled,
which is useful for sharing configs between hosts that use impermanence with
those who don't.
