### PR TITLE
nixos: Prevent redundant fstrim

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -56,7 +56,7 @@ let
     value = {
       device = concatPaths [ persistentStoragePath dirPath ];
       noCheck = true;
-      options = [ "bind" ]
+      options = [ "bind" "X-fstrim.notrim" ]
         ++ optional hideMount "x-gvfs-hide";
       depends = [ persistentStoragePath ];
     };


### PR DESCRIPTION
The fstrim service, when enabled, by default trims all mounts listed in fstab (as long as the underlying device supports discard), including bind mounts. With impermanence, this can lead to a significant number of redundant trim operations, since the persistent volume is trimmed once for itself and then again once per persistent directory each. On my system, this leads to fstrim.service taking about 10 minutes, during which the system usability is somewhat degraded. In addition, it may be desired to disable trim for a certain filesystem entirely, for example when using btrfs with discard=async.

Mark our bind mounts with the X-fstrim.notrim option, which is ignored by mount, but instructs fstrim to skip the mount point in question. The persistent filesystem is still trimmed properly, since it has to be listed in fstab itself as well.