### PR TITLE
Fix build with `documentation.nixos.includeAllModules = true;`

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -99,6 +99,7 @@ in
                   persistentStoragePath = mkOption {
                     type = path;
                     default = cfg.${name}.persistentStoragePath;
+                    defaultText = "environment.persistence.‹name›.persistentStoragePath";
                     description = ''
                       The path to persistent storage where the real
                       file or directory should be stored.
@@ -116,6 +117,7 @@ in
                   enableDebugging = mkOption {
                     type = bool;
                     default = cfg.${name}.enableDebugging;
+                    defaultText = "environment.persistence.‹name›.enableDebugging";
                     internal = true;
                     description = ''
                       Enable debug trace output when running
@@ -186,6 +188,7 @@ in
                   hideMount = mkOption {
                     type = bool;
                     default = cfg.${name}.hideMounts;
+                    defaultText = "environment.persistence.‹name›.hideMounts";
                     example = true;
                     description = ''
                       Whether to hide bind mounts from showing up as
@@ -238,6 +241,7 @@ in
                   persistentStoragePath = mkOption {
                     type = path;
                     default = name;
+                    defaultText = "‹name›";
                     description = ''
                       The path to persistent storage where the real
                       files and directories should be stored.


### PR DESCRIPTION
This includes the options of all modules used in the evaluation, not just the ones from `<nixpkgs/nixos>` in the local manual.

Right now this breaks with

    error: attribute '"‹name›"' missing

because the submodule `environment.persistence` doesn't have actual declarations when building the manual, but a dummy only to evaluate the sub-options (including their defaults which is the cause of the error) and generate documentation from that.

Using `defaultText` prevents that because there's no need anymore to evaluate the `default` values of the options.

cc @lovesegfault @talyz 