### PR TITLE
sanitizeName: don't clobber dots in names

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -56,9 +56,7 @@ let
       parents;
 
   sanitizeName = name:
-    replaceStrings
-      [ "." ] [ "" ]
-      (sanitizeDerivationName (removePrefix "/" name));
+      sanitizeDerivationName (removePrefix "/" name);
 
   duplicates = list:
     let


### PR DESCRIPTION
Fixes #132.

After rebuilding with this commit, a reboot (or maybe a `systemctl --user daemon-reexec`?) is required to successfully load and start the new units.