### PR TITLE
lib: Remove sanitizeName, replace usage with escapeSystemdPath

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, lib, ... }:
+{ pkgs, config, lib, utils, ... }:
 
 with lib;
 let
@@ -11,11 +11,14 @@ let
   isBindfs = v: (getDirMethod v) == "bindfs";
   isSymlink = v: (getDirMethod v) == "symlink";
 
+  inherit (utils)
+    escapeSystemdPath
+    ;
+
   inherit (pkgs.callPackage ./lib.nix { })
     splitPath
     dirListToPath
     concatPaths
-    sanitizeName
     ;
 
   mount = "${pkgs.util-linux}/bin/mount";
@@ -202,7 +205,7 @@ in
       let
         link = file:
           pkgs.runCommand
-            "${sanitizeName file}"
+            "${file}"
             { }
             "ln -s '${file}' $out";
 
@@ -235,7 +238,7 @@ in
                 dir;
             targetDir = escapeShellArg (concatPaths [ cfg.${persistentStorageName}.persistentStoragePath dir ]);
             mountPoint = escapeShellArg (concatPaths [ config.home.homeDirectory mountDir ]);
-            name = "bindMount-${sanitizeName targetDir}";
+            name = "bindMount-${escapeSystemdPath targetDir}";
             bindfsOptions = concatStringsSep "," (
               optional (!cfg.${persistentStorageName}.allowOther) "no-allow-other"
               ++ optional (versionAtLeast pkgs.bindfs.version "1.14.9") "fsname=${targetDir}"
@@ -342,7 +345,7 @@ in
                     if ! ${mount} | grep -F ${mountPoint}' ' | grep -F ${targetDir}' ' >/dev/null; then
                         # The target directory changed, so we need to remount
                         echo "remounting ${mountPoint}"
-                        ${systemctl} --user stop bindMount-${sanitizeName targetDir}
+                        ${systemctl} --user stop bindMount-${escapeSystemdPath targetDir}
                         ${bindfs} ${targetDir} ${mountPoint}
                         mountedPaths[${mountPoint}]=1
                     fi

--- a/lib.nix
+++ b/lib.nix
@@ -6,17 +6,12 @@ let
     concatStringsSep
     hasPrefix
     head
-    replaceStrings
     optionalString
-    removePrefix
     foldl'
     elem
     take
     length
     last
-    ;
-  inherit (lib.strings)
-    sanitizeDerivationName
     ;
 
   # ["/home/user/" "/.screenrc"] -> ["home" "user" ".screenrc"]
@@ -55,11 +50,6 @@ let
       [ ]
       parents;
 
-  sanitizeName = name:
-    replaceStrings
-      [ "." ] [ "" ]
-      (sanitizeDerivationName (removePrefix "/" name));
-
   duplicates = list:
     let
       result =
@@ -85,7 +75,6 @@ in
     dirListToPath
     concatPaths
     parentsOf
-    sanitizeName
     duplicates
     ;
 }

--- a/nixos.nix
+++ b/nixos.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, lib, ... }:
+{ pkgs, config, lib, utils, ... }:
 
 let
   inherit (lib)
@@ -31,11 +31,14 @@ let
     mapAttrs
     ;
 
+  inherit (utils)
+    escapeSystemdPath
+    ;
+
   inherit (pkgs.callPackage ./lib.nix { })
     splitPath
     dirListToPath
     concatPaths
-    sanitizeName
     duplicates
     parentsOf
     ;
@@ -483,7 +486,7 @@ in
             mountPoint = escapeShellArg filePath;
           in
           {
-            "persist-${sanitizeName targetFile}" = {
+            "persist-${escapeSystemdPath targetFile}" = {
               description = "Bind mount or link ${targetFile} to ${mountPoint}";
               wantedBy = [ "local-fs.target" ];
               before = [ "local-fs.target" ];
@@ -493,7 +496,7 @@ in
                 Type = "oneshot";
                 RemainAfterExit = true;
                 ExecStart = "${mountFile} ${mountPoint} ${targetFile} ${escapeShellArg enableDebugging}";
-                ExecStop = pkgs.writeShellScript "unbindOrUnlink-${sanitizeName targetFile}" ''
+                ExecStop = pkgs.writeShellScript "unbindOrUnlink-${escapeSystemdPath targetFile}" ''
                   set -eu
                   if [[ -L ${mountPoint} ]]; then
                       rm ${mountPoint}


### PR DESCRIPTION
`sanitizeName` is not necessary anymore and can be replaced by `utils.escapeSystemdPath`, which does a much better job anyway.

Fixes #132.