### PR TITLE
Add capability to let impemanence create the `persistentStoragePath`

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -248,6 +248,18 @@ in
                     description = ''
                       The path to persistent storage where the real
                       files and directories should be stored.
+
+                      This directory will be created if createPersistentStoragePath is set.
+                    '';
+                  };
+
+                  createPersistentStoragePath = mkOption {
+                    type = bool;
+                    default = false;
+                    description = ''
+                      If set and persistentStoragePath does not exist then the directory
+                      persistentStoragePath will be created.  The owner of the directory
+                      will be root.
                     '';
                   };
 
@@ -669,6 +681,7 @@ in
           deps = [ "users" "groups" ];
           text =
             lib.pipe config.environment.persistence [
+              (lib.filterAttrs (_: storage: storage.createPersistentStoragePath))
               (lib.mapAttrsToList (_: storage: storage.persistentStoragePath))
               (lib.sort (a: b: lib.hasPrefix a b))
               # trailing newline is included in indent string

--- a/nixos.nix
+++ b/nixos.nix
@@ -255,7 +255,7 @@ in
 
                   createPersistentStoragePath = mkOption {
                     type = bool;
-                    default = false;
+                    default = true;
                     description = ''
                       If set and persistentStoragePath does not exist then the directory
                       persistentStoragePath will be created.  The owner of the directory


### PR DESCRIPTION
Add option `createPersistentStoragePath` (bool) which, if set, creates the directory `persistentStoragePath` during activation phase. The default is set to `true` as I think this is what most people expect and also avoids some permissions mismatches (see below). If you do not agree for whatever reason, feel free to drop the commit enabling it by default.

The permission mismatch might also be related to #139.

## More Background

Beginning of the story is, that I bootstrapped a new system with this config:
```nix
  environment.persistence."home" = {
    persistentStoragePath = "/persist/user/this/dir/does/not/yet/exist";
    users."me" = {
      directories = [
        "cooldir"
      ];
    };
  };
```

After rebooting, cooldir was created by owned by root. It took me a while but the problem is/was that impermanence failed to create `/home/me/cooldir` inside the `persistentStoragePath` location (because that directory does not exist).  However, a bind entry was created in `/etc/fstab` which triggered systemd-fstab-generator to generated that mount and in the process also create the missing directories but with root permissions.

With this PR the config could look like
```nix
  environment.persistence."home" = {
    persistentStoragePath = "/persist/user/this/dir/does/not/yet/exist";
    createPersistentStoragePath = true;
    users."me" = {
      directories = [
        "cooldir"
      ];
    };
  };
```