### PR TITLE
Fix issue with directories not being found

### DIFF
--- a/create-directories.bash
+++ b/create-directories.bash
@@ -48,7 +48,7 @@ fi
 realSource="$(realpath -m "$sourceBase$target")"
 if [[ ! -d "$realSource" ]]; then
     printf "Warning: Source directory '%s' does not exist; it will be created for you with the following permissions: owner: '%s:%s', mode: '%s'.\n" "$realSource" "$user" "$group" "$mode"
-    mkdir --mode="$mode" "$realSource"
+    mkdir -p --mode="$mode" "$realSource"
     chown "$user:$group" "$realSource"
 fi
 


### PR DESCRIPTION
An error was happening to me on a new NixOS installation when booting for the first time. It said something about a persistent directory not being found, and I was able to rectify the error with this simple fix.