### PR TITLE
Add global enable switches for nixos and home-manager

### DIFF
--- a/README.org
+++ b/README.org
@@ -195,6 +195,17 @@
     attribute set of submodules, where the attribute name is the path
     to persistent storage.
 
+    The impermanence module is enabled by default. It can be globally disabled
+    when imported, removing all side-effects (such as additional activation
+    scripts). This can be helpful when using a single configuration for multiple
+    systems which imports the module globally. To disable impermanence, use:
+
+    #+begin_src nix
+      {
+        boot.impermanence.enable = false;
+      }
+    #+end_src
+
     Usage is shown best with an example:
 
     #+begin_src nix
@@ -347,6 +358,18 @@
     This adds the ~home.persistence~ option, which is an attribute set
     of submodules, where the attribute name is the path to persistent
     storage.
+
+    The home-manager module is enabled by default. It can be globally disabled
+    when imported, removing all side-effects (such as additional activation
+    scripts). This can be helpful when using a single configuration for multiple
+    systems which imports the module globally. To disable the home-manager
+    module, use:
+
+    #+begin_src nix
+      {
+        home.impermanence.enable = false;
+      }
+    #+end_src
 
     Usage is shown best with an example:
 

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -2,6 +2,7 @@
 
 with lib;
 let
+  enableCfg = config.home.impermanence.enable;
   cfg = config.home.persistence;
 
   persistentStorageNames = attrNames cfg;
@@ -40,7 +41,14 @@ let
 in
 {
   options = {
-
+    home.impermanence.enable = mkOption {
+      type = types.bool;
+      description = ''
+        Whether to enable impermanence for home-manager.
+        Defaults to "true".
+      '';
+      default = true;
+    };
     home.persistence = mkOption {
       default = { };
       type = with types; attrsOf (
@@ -197,7 +205,7 @@ in
 
   };
 
-  config = {
+  config = lib.mkIf enableCfg {
     home.file =
       let
         link = file:

--- a/nixos.nix
+++ b/nixos.nix
@@ -44,6 +44,7 @@ let
     ;
 
   cfg = config.environment.persistence;
+  enableCfg = config.boot.impermanence.enable;
   users = config.users.users;
   allPersistentStoragePaths = { directories = [ ]; files = [ ]; users = [ ]; }
     // (zipAttrsWith (_name: flatten) (filter (v: v.enable) (attrValues cfg)));
@@ -71,7 +72,14 @@ let
 in
 {
   options = {
-
+    boot.impermanence.enable = mkOption {
+      type = types.bool;
+      description = ''
+        Whether to enable impermanence.
+        Defaults to "true".
+      '';
+      default = true;
+    };
     environment.persistence = mkOption {
       default = { };
       type =
@@ -477,7 +485,7 @@ in
     virtualisation.fileSystems = mkOption { };
   };
 
-  config = {
+  config = lib.mkIf enableCfg {
     systemd.services =
       let
         mkPersistFileService = { filePath, persistentStoragePath, enableDebugging, ... }:


### PR DESCRIPTION
In #138 and #167, requests for some global `enable` option were made.

I've also found some use-cases where I'd like to disable all side-effects of the `impermanence` modules for specific configurations while globally importing the modules. Though setting `environment.persistence` to `{}` generally works, it has two drawbacks:

* You can't declare `environment.persistence` and then easily globally disable them somewhere else, without forcing it to `{}` (see #138).
* Some side-effects always remain on the system (such as empty activation scripts).

This PR adds two additional options to `impermanence`:

* `boot.impermanence.enable`: This switch is enabled by default and, if disabled, deactivates the entire module.
* `home.impermanence.enable`: This switch does the same for `home-manager.nix`

I'd rather have this module be disabled by default (as most `nixos` modules are) but this would break every current install when updating which would be *very bad*. Instead, these new options are enabled by default, which means current installs would not be affected at all by these changes.

I put the `nixos` switch into `boot` because I felt that this module mostly affects the boot process (though some systemd services are started as well). I'm open to any suggestions for better placement.