### PR TITLE
hm: option for default linking method

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -39,7 +39,7 @@ in
     home.persistence = mkOption {
       default = { };
       type = with types; attrsOf (
-        submodule ({ name, ... }: {
+        submodule ({ name, config, ... }: {
           options =
             {
               persistentStoragePath = mkOption {
@@ -57,6 +57,18 @@ in
                 description = "Whether to enable this persistent storage location.";
               };
 
+              defaultDirectoryMethod = mkOption {
+                type = types.enum [ "bindfs" "symlink" ];
+                default = "bindfs";
+                description = ''
+                  The linking method that should be used for directories.
+                  bindfs is the default and works for most use cases, however
+                  some programs may behave better with symlinks.
+
+                  This can be overridden on a per entry basis.
+                '';
+              };
+
               directories = mkOption {
                 type = types.listOf (
                   types.coercedTo types.str (directory: { inherit directory; }) (submodule {
@@ -67,12 +79,11 @@ in
                       };
                       method = mkOption {
                         type = types.enum [ "bindfs" "symlink" ];
-                        default = "bindfs";
+                        default = config.defaultDirectoryMethod;
                         description = ''
-                          The linking method that should be used for this
-                          directory. bindfs is the default and works for most use
-                          cases, however some programs may behave better with
-                          symlinks.
+                          The linking method to be used for this specific
+                          directory entry. Defaults to
+                          <literal>defaultDirectoryMethod</literal>.
                         '';
                       };
                     };

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -62,8 +62,14 @@ in
                 default = "bindfs";
                 description = ''
                   The linking method that should be used for directories.
-                  bindfs is the default and works for most use cases, however
-                  some programs may behave better with symlinks.
+
+                  - bindfs is very transparent, and thus used as a safe
+                  default. It has, however, a significant performance impact in
+                  IO-heavy situations.
+
+                  - symlinks have great performance but may be treated
+                  specially by some programs that may e.g. generate
+                  errors/warnings, or replace them.
 
                   This can be overridden on a per entry basis.
                 '';
@@ -82,8 +88,9 @@ in
                         default = config.defaultDirectoryMethod;
                         description = ''
                           The linking method to be used for this specific
-                          directory entry. Defaults to
-                          <literal>defaultDirectoryMethod</literal>.
+                          directory entry. See
+                          <literal>defaultDirectoryMethod</literal> for more
+                          information on the tradeoffs.
                         '';
                       };
                     };

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -238,7 +238,7 @@ in
         mkLinksToPersistentStorage = persistentStorageName:
           listToAttrs (map
             (mkLinkNameValuePair persistentStorageName)
-            (map (v: v.directory) (cfg.${persistentStorageName}.files ++
+            (cfg.${persistentStorageName}.files ++ (map (v: v.directory)
               (filter (v: v.method == "symlink") cfg.${persistentStorageName}.directories)))
           );
       in
@@ -477,7 +477,7 @@ in
                     (targetFilePath: ''
                       mkdir -p ${escapeShellArg (concatPaths [ cfg.${persistentStorageName}.persistentStoragePath (dirOf targetFilePath) ])}
                     '')
-                    (map (v: v.directory) (cfg.${persistentStorageName}.files ++ (filter (v: v.method == "symlink") cfg.${persistentStorageName}.directories))))
+                    (cfg.${persistentStorageName}.files ++ (map (v: v.directory) (filter (v: v.method == "symlink") cfg.${persistentStorageName}.directories))))
                 persistentStorageNames);
         })
       ];


### PR DESCRIPTION
Hi all!

Here's a (slightly late) follow up to https://github.com/nix-community/impermanence/pull/99.

This adds an option that allows users to change the default linking method.

Bindfs has been bothering me with the performance hits, and writing `method = symlink` for every entry is cumbersome. The default still is bindfs, so no breaking changes.

To make this implementation cleaner, I also refactored the directory type to use coercedTo (in its own commit, to be easier to review).
