### PR TITLE
mount-file: allow file to exist if it's empty

### DIFF
--- a/mount-file.bash
+++ b/mount-file.bash
@@ -32,7 +32,7 @@ if [[ -L "$mountPoint" && $(readlink -f "$mountPoint") == "$targetFile" ]]; then
     trace "$mountPoint already links to $targetFile, ignoring"
 elif mount | grep -F "$mountPoint"' ' >/dev/null && ! mount | grep -F "$mountPoint"/ >/dev/null; then
     trace "mount already exists at $mountPoint, ignoring"
-elif [[ -e "$mountPoint" ]]; then
+elif [[ -s "$mountPoint" ]]; then
     echo "A file already exists at $mountPoint!" >&2
     exit 1
 elif [[ -e "$targetFile" ]]; then


### PR DESCRIPTION
Sometimes the root filesystem may not have been cleaned up or reset correctly, and this handles such situations more gracefully.