### PR TITLE
nixos: Disable module if no persistent storage paths are defined or all are disabled

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -8,6 +8,7 @@ let
     flatten
     mkOption
     mkDefault
+    mkIf
     mapAttrsToList
     types
     foldl'
@@ -41,8 +42,7 @@ let
 
   cfg = config.environment.persistence;
   users = config.users.users;
-  allPersistentStoragePaths = { directories = [ ]; files = [ ]; users = [ ]; }
-    // (zipAttrsWith (_name: flatten) (filter (v: v.enable) (attrValues cfg)));
+  allPersistentStoragePaths = zipAttrsWith (_name: flatten) (filter (v: v.enable) (attrValues cfg));
   inherit (allPersistentStoragePaths) files directories;
   mountFile = pkgs.runCommand "impermanence-mount-file" { buildInputs = [ pkgs.bash ]; } ''
     cp ${./mount-file.bash} $out
@@ -472,7 +472,7 @@ in
     virtualisation.fileSystems = mkOption { };
   };
 
-  config = {
+  config = mkIf (allPersistentStoragePaths != { }) {
     systemd.services =
       let
         mkPersistFileService = { filePath, persistentStoragePath, enableDebugging, ... }:

--- a/nixos.nix
+++ b/nixos.nix
@@ -22,11 +22,9 @@ let
     filterAttrs
     concatStringsSep
     concatMapStringsSep
-    isString
     catAttrs
     optional
     literalExpression
-    optionalString
     elem
     mapAttrs
     ;
@@ -36,8 +34,6 @@ let
     ;
 
   inherit (pkgs.callPackage ./lib.nix { })
-    splitPath
-    dirListToPath
     concatPaths
     duplicates
     parentsOf
@@ -83,7 +79,6 @@ in
             submodule
             nullOr
             path
-            either
             str
             coercedTo
             ;


### PR DESCRIPTION
Previously, we would always make some meaningless additions to `activationScripts` and such.

Also, remove some unused lib function imports from the module.

cc @0xf09f95b4