### PR TITLE
nixos: avoid side effects to fileSystems if possible

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -506,9 +506,9 @@ in
       in
       foldl' recursiveUpdate { } (map mkPersistFileService files);
 
-    fileSystems = bindMounts;
+    fileSystems = mkIf (directories != [ ]) bindMounts;
     # So the mounts still make it into a VM built from `system.build.vm`
-    virtualisation.fileSystems = bindMounts;
+    virtualisation.fileSystems = mkIf (directories != [ ]) bindMounts;
 
     system.activationScripts =
       let


### PR DESCRIPTION
This is a good idea in itself.

Additionally, it avoids issues if users want to use mkDefault in their fileSystems config and have no persistent directories.