### PR TITLE
Add -p to mkdir

### DIFF
--- a/create-directories.bash
+++ b/create-directories.bash
@@ -48,7 +48,7 @@ fi
 realSource="$(realpath -m "$sourceBase$target")"
 if [[ ! -d "$realSource" ]]; then
     printf "Warning: Source directory '%s' does not exist; it will be created for you with the following permissions: owner: '%s:%s', mode: '%s'.\n" "$realSource" "$user" "$group" "$mode"
-    mkdir --mode="$mode" "$realSource"
+    mkdir -p --mode="$mode" "$realSource"
     chown "$user:$group" "$realSource"
 fi
 


### PR DESCRIPTION
When using the impermanence module, the script will not create the /persist/system directory without `-p` flag:

```
environment.persistence."/persist/system" = {
  hideMounts = true;
  directories = [
    "/etc/nixos"
    "/var/log"
    "/var/lib/bluetooth"
    "/var/lib/nixos"
    "/var/lib/systemd/coredump"
    "/etc/NetworkManager/system-connections"
    {
      directory = "/var/lib/colord";
      user = "colord";
      group = "colord";
      mode = "u=rwx,g=rx,o=";
    }
  ];
  files = [
    "/etc/machine-id"
    {
      file = "/var/keys/secret_file";
      parentDirectory = {
        mode = "u=rwx,g=,o=";
      };
    }
  ];
};
```

Error output on `nixos-install`:

```
Warning: Source directory '/persist/system/etc' does not exist; it will be created for you with the following permissions: owner: 'root:root', mode: '0755'.
mkdir: cannot create directory ‘/persist/system/etc’: No such file or directory
Error when executing mkdir --mode="$mode" "$realSource" at line 51!
```