### PR TITLE
home-manager: Add home-manager module dependency ordering

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -37,7 +37,7 @@ let
     in
     prefix + path;
 
-
+  # "/home/user/.screenrc" -> ["/home", "/home/user"]
   parentsOf = path:
     let
       prefix = optionalString (hasPrefix "/" path) "/";
@@ -60,6 +60,7 @@ let
       [ "." ] [ "" ]
       (sanitizeDerivationName (removePrefix "/" name));
 
+  # ["a", "b", "a"] -> ["a"]
   duplicates = list:
     let
       result =

--- a/lib.nix
+++ b/lib.nix
@@ -14,6 +14,7 @@ let
     take
     length
     last
+    escapeShellArg
     ;
   inherit (lib.strings)
     sanitizeDerivationName
@@ -79,6 +80,10 @@ let
           list;
     in
     result.duplicates;
+
+  mkMountPath = root: child: escapeShellArg (concatPaths [ root child ]);
+
+  mkServiceName = root: child: "bindMount-${sanitizeName (mkMountPath root child)}";
 in
 {
   inherit
@@ -88,5 +93,7 @@ in
     parentsOf
     sanitizeName
     duplicates
+    mkMountPath
+    mkServiceName
     ;
 }


### PR DESCRIPTION
This PR is intended to add a rudimentary dependency check to Impermanence's home-manager module.

## Reasoning

Setting up nested persistent directories such as the following...

```
    home.persistence = {
      "/persist${user.home}".directories = [ ".config/Code" ];
      # https://github.com/microsoft/vscode/issues/3884
      "/cache${user.home}".directories = [
        ".config/Code/Cache"
        ".config/Code/CachedConfigurations"
        ".config/Code/CachedData"
        ".config/Code/CachedExtensionVSIXs"
        ".config/Code/CachedExtensions"
        ".config/Code/CachedProfilesData"
        ".config/Code/Code Cache"
        ".config/Code/DawnCache"
        ".config/Code/GPUCache"
        ".config/Code/Service Worker/CacheStorage"
        ".config/Code/Service Worker/ScriptCache"
      ];
    };
```

... causes issues, since `/cache` gets bind-mounted first, then `/persist` refuses to mount over it.

## Included Changes

- Collect user mount options, then sort based on target directory before iterating, as opposed to the previous alphabetical ordering seen in #22
- Add `systemd` service dependencies where needed
  - The implementation for this is a relatively inefficient $O(n^2)$, perhaps a topological sort like in #97 is a better option?
- Export `lib` functions `mkMountPath` and `mkServiceName`, which should make it easier to set service dependencies in users' configs #94
