### PR TITLE
Add warning regarding home-manager module

### DIFF
--- a/README.org
+++ b/README.org
@@ -422,6 +422,9 @@
     the directories you add will be visible in the ~/etc/mtab~ file and in the
     output of ~mount~ to all users.
 
+    /Warning:/ Do not add `.config/systemd` folder when using home-manager's module
+    otherwise it won't work.
+
 ** Further reading
    The following blog posts provide more information on the concept of ephemeral
    roots:


### PR DESCRIPTION
Impermanence within home-manager will not work if  `~/.config/systemd` is added. 

See https://github.com/nix-community/impermanence/issues/198#issuecomment-2312122729

Ideally this should be an assertion instead to avoid building broken builds, would you like me to update?