### PR TITLE
homeManagerModules attripute naming outside nixosModules

### DIFF
--- a/README.org
+++ b/README.org
@@ -349,6 +349,29 @@
       }
     #+end_src
 
+    or use the provided ~homeManagerModules.impermanence~ flake output:
+
+    #+end_src
+
+    #+begin_src nix
+      {
+        inputs = {
+          impermanence.url = "github:nix-community/impermanence";
+        };
+
+        outputs = { self, nixpkgs, impermanence, ... }:
+          {
+            homeConfigurations.sythe = home-manager.lib.homeManagerConfiguration {
+            inherit pkgs;
+            modules = [
+                impermanence.homeManagerModules.impermanence
+                ./machines/sythe/home.nix
+              ];
+            };
+          };
+      }
+    #+end_src
+
     This adds the ~home.persistence~ option, which is an attribute set
     of submodules, where the attribute name is the path to persistent
     storage.

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,6 @@
     nixosModules.impermanence = import ./nixos.nix;
     nixosModules.home-manager.impermanence = import ./home-manager.nix;
     nixosModule = self.nixosModules.impermanence;
-    homeManagerModules.impermanence = import ./home-manager.nix
+    homeManagerModules.impermanence = import ./home-manager.nix;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,5 +3,6 @@
     nixosModules.impermanence = import ./nixos.nix;
     nixosModules.home-manager.impermanence = import ./home-manager.nix;
     nixosModule = self.nixosModules.impermanence;
+    homeManagerModules.impermanence = import ./home-manager.nix
   };
 }


### PR DESCRIPTION
adding flake output homeManagerModules.impermanence just not to cause confusion if used with standalone home-manager flake setup (as one usually does not use nixosModules attribute in defining a homeManager module in such a case even though it would work here !, although keeping the old flake output ~nixosModules.home-manager.impermanence is a good idea for backward compatibility. 