### PR TITLE
nixos: Fix duplicate definition causing syntax error

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -7,7 +7,6 @@ let
     zipAttrsWith
     flatten
     mkAfter
-    mkIf
     mkOption
     mkDefault
     mkIf


### PR DESCRIPTION
`mkIf` is already defined here.