### PR TITLE
Fix machine-id workaround to also work on first boot

### DIFF
--- a/create-directories.bash
+++ b/create-directories.bash
@@ -28,7 +28,7 @@ trap 'echo Error when executing ${BASH_COMMAND} at line ${LINENO}! >&2' ERR
 #   3. Copy the mode of the source path to the target path
 
 # Get inputs from command line arguments
-if [[ "$#" != 6 ]]; then
+if [[ $# != 6 ]]; then
     printf "Error: 'create-directories.bash' requires *six* args.\n" >&2
     exit 1
 fi
@@ -39,7 +39,7 @@ group="$4"
 mode="$5"
 debug="$6"
 
-if (( "$debug" )); then
+if (( debug )); then
     set -o xtrace
 fi
 

--- a/mount-file.bash
+++ b/mount-file.bash
@@ -10,7 +10,7 @@ shopt -s inherit_errexit  # Inherit the errexit option status in subshells.
 trap 'echo Error when executing ${BASH_COMMAND} at line ${LINENO}! >&2' ERR
 
 # Get inputs from command line arguments
-if [[ "$#" != 3 ]]; then
+if [[ $# != 3 ]]; then
     echo "Error: 'mount-file.bash' requires *three* args." >&2
     exit 1
 fi
@@ -20,22 +20,22 @@ targetFile="$2"
 debug="$3"
 
 trace() {
-    if (( "$debug" )); then
+    if (( debug )); then
       echo "$@"
     fi
 }
-if (( "$debug" )); then
+if (( debug )); then
     set -o xtrace
 fi
 
-if [[ -L "$mountPoint" && $(readlink -f "$mountPoint") == "$targetFile" ]]; then
+if [[ -L $mountPoint && $(readlink -f "$mountPoint") == "$targetFile" ]]; then
     trace "$mountPoint already links to $targetFile, ignoring"
 elif findmnt "$mountPoint" >/dev/null; then
     trace "mount already exists at $mountPoint, ignoring"
-elif [[ -s "$mountPoint" ]]; then
+elif [[ -s $mountPoint ]]; then
     echo "A file already exists at $mountPoint!" >&2
     exit 1
-elif [[ -e "$targetFile" ]]; then
+elif [[ -e $targetFile ]]; then
     touch "$mountPoint"
     mount -o bind "$targetFile" "$mountPoint"
 else

--- a/mount-file.bash
+++ b/mount-file.bash
@@ -38,6 +38,13 @@ elif [[ -s $mountPoint ]]; then
 elif [[ -e $targetFile ]]; then
     touch "$mountPoint"
     mount -o bind "$targetFile" "$mountPoint"
+elif [[ $mountPoint == "/etc/machine-id" ]]; then
+    # Work around an issue with persisting /etc/machine-id. For more
+    # details, see https://github.com/nix-community/impermanence/pull/242
+    echo "Creating initial /etc/machine-id"
+    echo "uninitialized" > "$targetFile"
+    touch "$mountPoint"
+    mount -o bind "$targetFile" "$mountPoint"
 else
     ln -s "$targetFile" "$mountPoint"
 fi

--- a/nixos.nix
+++ b/nixos.nix
@@ -781,13 +781,14 @@ in
       }
 
       # Work around an issue with persisting /etc/machine-id where the
-      # systemd-machine-id-commit.service unit fails if
+      # systemd-machine-id-commit.service unit fails if the final
       # /etc/machine-id is bind mounted from persistent storage. For
       # more details, see
-      # https://github.com/nix-community/impermanence/issues/229
+      # https://github.com/nix-community/impermanence/issues/229 and
+      # https://github.com/nix-community/impermanence/pull/242
       (mkIf (any (f: f == "/etc/machine-id") (catAttrs "filePath" files)) {
         boot.initrd.systemd.suppressedUnits = [ "systemd-machine-id-commit.service" ];
-        systemd.suppressedSystemUnits = [ "systemd-machine-id-commit.service" ];
+        systemd.services.systemd-machine-id-commit.unitConfig.ConditionFirstBoot = true;
       })
 
       # Assertions and warnings


### PR DESCRIPTION
To make this work, we have to do two things:

### Run the `systemd-machine-id-commit` service only on first boot

`systemd-machine-id-commit` does its job just fine if the file contains `uninitialized`, even if it's bind mounted from persistent storage. It only misbehaves if the file contains an actual machine-id, since it then thinks it needs to be committed.

This can be worked around by only running the service on the first boot.

### Create the machine-id file with the string `uninitialized` in it

Our standard handling of non-existent files is to create a symlink, but this makes systemd behave a bit strangely. It follows the symlink and creates the `uninitialized` machine-id at the linked location. Then it bind mounts a newly generated machine-id over the file in persistent storage. This works, but it seems to confuse `systemd-machine-id-commit` since the file is not actually a bind mount over /etc/machine-id, so the machine-id will not be committed on this boot cycle and will still contain `uninitialized` on the next boot. This makes the next boot also recognized as the “first boot”. This time, however, `systemd-machine-id-commit` does its job, since the file is a bind mount to persistent storage.

The workaround for this is to just skip the symlinking step and go straight to bind mounting. However, since the file needs to exist to be bind mounted, we also have to create it with the string `uninitialized` as its contents.