### PR TITLE
Add an `allowTrash` option set to `true` by default to the NixOS module

### DIFF
--- a/README.org
+++ b/README.org
@@ -202,6 +202,7 @@
         environment.persistence."/persistent" = {
           enable = true;  # NB: Defaults to true, not needed
           hideMounts = true;
+          allowTrash = true;
           directories = [
             "/var/log"
             "/var/lib/bluetooth"
@@ -251,6 +252,11 @@
       bind mounts from showing up as mounted drives in the file
       manager. If enabled, it sets the mount option ~x-gvfs-hide~
       on all the bind mounts.
+
+    - ~allowTrash~ allows you to specify whether to allow apps that use
+      certain GTK-based technologies such as GIO to put items in the
+      trash. If enabled, it sets the mount option ~x-gvfs-trash~ on all
+      the bind mounts.
 
     - ~directories~ are all directories you want to bind mount to
       persistent storage. A directory can be represented either as a

--- a/nixos.nix
+++ b/nixos.nix
@@ -70,7 +70,7 @@ let
       device = concatPaths [ persistentStoragePath dirPath ];
       noCheck = true;
       options = [ "bind" "X-fstrim.notrim" ]
-        ++ optional hideMount "x-gvfs-hide";
+        ++ optional hideMount "x-gvfs-hide"
         ++ optional allowTrash "x-gvfs-trash";
       depends = [ persistentStoragePath ];
     };

--- a/nixos.nix
+++ b/nixos.nix
@@ -64,13 +64,14 @@ let
   };
 
   # Create fileSystems bind mount entry.
-  mkBindMountNameValuePair = { dirPath, persistentStoragePath, hideMount, ... }: {
+  mkBindMountNameValuePair = { dirPath, persistentStoragePath, hideMount, allowTrash, ... }: {
     name = concatPaths [ "/" dirPath ];
     value = {
       device = concatPaths [ persistentStoragePath dirPath ];
       noCheck = true;
       options = [ "bind" "X-fstrim.notrim" ]
         ++ optional hideMount "x-gvfs-hide";
+        ++ optional allowTrash "x-gvfs-trash";
       depends = [ persistentStoragePath ];
     };
   };
@@ -200,6 +201,15 @@ in
                     description = ''
                       Whether to hide bind mounts from showing up as
                       mounted drives.
+                    '';
+                  };
+                  allowTrash = mkOption {
+                    type = bool;
+                    default = config.allowTrash;
+                    defaultText = "environment.persistence.‹name›.allowTrash";
+                    example = true;
+                    description = ''
+                      Whether to allow newer GIO-based applications to trash files.
                     '';
                   };
                   # Save the default permissions at the level the
@@ -419,6 +429,14 @@ in
                     example = true;
                     description = ''
                       Whether to hide bind mounts from showing up as mounted drives.
+                    '';
+                  };
+                  allowTrash = mkOption {
+                    type = bool;
+                    default = true;
+                    example = true;
+                    description = ''
+                      Whether to allow newer GIO-based applications to trash files.
                     '';
                   };
 


### PR DESCRIPTION
I ran into this issue about twenty minutes ago and tried my hand at fixing it. This resolves _parts of_ #147.

Newer versions of glib's trash implementation support an `x-gvfs-trash` mount option on bind mounts, that overrides the "internal filesystem" error that some people in #147 have been facing. 

This error is basically glib refusing to put things into a bind-mounted trash folder. I have added an option to the NixOS module that fixes this error by default, and is opt-out, but I would be fine making it opt-in if that fits the goals of the project better. I've confirmed that this works on my machine, but if people could test it out on theirs that would be great!

Please let me know if I've missed anything - I'm still relatively new to open-source and I am very tired right now :)

Relevant merge requests:
https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4155
https://gitlab.gnome.org/GNOME/gvfs/-/merge_requests/222

Relevant issues:
https://github.com/nix-community/impermanence/issues/147
https://gitlab.gnome.org/GNOME/glib/-/issues/1885