### PR TITLE
nixos: Improve handling of special file systems in create-needed-for-boot

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -795,7 +795,7 @@ in
                 script = createNeededForBootDirs;
               };
             };
-            postDeviceCommands = mkIf (!config.boot.initrd.systemd.enable)
+            postResumeCommands = mkIf (!config.boot.initrd.systemd.enable)
               (mkAfter createNeededForBootDirs);
           };
       }


### PR DESCRIPTION
When generating the dependencies for the systemd unit, take into account the special cases where there not be any backing file system.

Fixes #237.
Fixos #239.