### PR TITLE
fix: missing binary in activation script

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -19,17 +19,18 @@ let
     ;
 
   mount = "${pkgs.util-linux}/bin/mount";
+  fusermount = "${lib.getExe' pkgs.fuse "fusermount"}"
   unmountScript = mountPoint: tries: sleep: ''
     triesLeft=${toString tries}
     if ${mount} | grep -F ${mountPoint}' ' >/dev/null; then
         while (( triesLeft > 0 )); do
-            if fusermount -u ${mountPoint}; then
+            if ${fusermount} -u ${mountPoint}; then
                 break
             else
                 (( triesLeft-- ))
                 if (( triesLeft == 0 )); then
                     echo "Couldn't perform regular unmount of ${mountPoint}. Attempting lazy unmount."
-                    fusermount -uz ${mountPoint}
+                    ${fusermount} -uz ${mountPoint}
                 else
                     sleep ${toString sleep}
                 fi


### PR DESCRIPTION
Had an issue when moving some directories over to symlink after being bindfs mounts, encountered this error on my next home-manager activation.

This patch should ensure that `fusermount` is not missing by referencing a binary within the store.

Log:
```
warning: the following units failed: home-manager-racci.service
× home-manager-racci.service - Home Manager environment for racci
     Loaded: loaded (/etc/systemd/system/home-manager-racci.service; enabled; preset: ignored)
     Active: failed (Result: exit-code) since Tue 2024-12-31 18:34:36 AEDT; 260ms ago
 Invocation: 93b46f796df94e409da03faadbe01b38
    Process: 1562829 ExecStart=/nix/store/m91h9kmjw78swvldfb9px8qnv1nb23ax-hm-setup-env /nix/store/lshgw95gk6rkyaw5kq3rcypq3g9rrj72-home-manager-generation (code=exited, status=127)
   Main PID: 1562829 (code=exited, status=127)
         IP: 0B in, 0B out
         IO: 64K read, 0B written
   Mem peak: 6.4M
        CPU: 83ms

Dec 31 18:34:34 nixe hm-activate-racci[1562829]: Activating checkFilesChanged
Dec 31 18:34:34 nixe hm-activate-racci[1562829]: Activating cleanEmptyLinkTargets
Dec 31 18:34:34 nixe hm-activate-racci[1562895]: /nix/store/lshgw95gk6rkyaw5kq3rcypq3g9rrj72-home-manager-generation/activate: line 250: fusermount: command not found
Dec 31 18:34:35 nixe hm-activate-racci[1563086]: /nix/store/lshgw95gk6rkyaw5kq3rcypq3g9rrj72-home-manager-generation/activate: line 250: fusermount: command not found
Dec 31 18:34:36 nixe hm-activate-racci[1563088]: /nix/store/lshgw95gk6rkyaw5kq3rcypq3g9rrj72-home-manager-generation/activate: line 250: fusermount: command not found
Dec 31 18:34:36 nixe hm-activate-racci[1562829]: Couldn't perform regular unmount of /home/racci/.config/Nextcloud. Attempting lazy unmount.
Dec 31 18:34:36 nixe hm-activate-racci[1563089]: /nix/store/lshgw95gk6rkyaw5kq3rcypq3g9rrj72-home-manager-generation/activate: line 256: fusermount: command not found
Dec 31 18:34:36 nixe systemd[1]: home-manager-racci.service: Main process exited, code=exited, status=127/n/a
Dec 31 18:34:36 nixe systemd[1]: home-manager-racci.service: Failed with result 'exit-code'.
Dec 31 18:34:36 nixe systemd[1]: Failed to start Home Manager environment for racci.
warning: error(s) occurred while switching to the new configuration
```