### PR TITLE
mount-file: add -h option to touch

### DIFF
--- a/mount-file.bash
+++ b/mount-file.bash
@@ -36,7 +36,7 @@ elif [[ -s $mountPoint ]]; then
     echo "A file already exists at $mountPoint!" >&2
     exit 1
 elif [[ -e $targetFile ]]; then
-    touch "$mountPoint"
+    touch -h "$mountPoint"
     mount -o bind "$targetFile" "$mountPoint"
 elif [[ $mountPoint == "/etc/machine-id" ]]; then
     # Work around an issue with persisting /etc/machine-id. For more


### PR DESCRIPTION
.. to make it work when mount point is a dangling symlink.

For example, if `~/.bash_profile` is a dangling symlink (it point to `/some/file` but `/some/file` does not exist), it will fail with the following error:

```
Jan 14 16:14:14 srv2-node1 b9nngyrdsqkbshcvd42a5mi6xizflfw6-impermanence-mount-file[2112]: touch: cannot touch '/home/chn/.bash_profile': No such file or directory
Jan 14 16:14:14 srv2-node1 b9nngyrdsqkbshcvd42a5mi6xizflfw6-impermanence-mount-file[2072]: Error when executing touch "$mountPoint" at line 39!
Jan 14 16:14:14 srv2-node1 systemd[1]: persist-nix-store-8qi3dx1w9c1r2ngm542vcpz3a9mvydsh\x2duser\x2dfiles-home-chn-.bash_profile.service: Main process exited, code=exited, status=1/FAILURE
Jan 14 16:14:14 srv2-node1 systemd[1]: persist-nix-store-8qi3dx1w9c1r2ngm542vcpz3a9mvydsh\x2duser\x2dfiles-home-chn-.bash_profile.service: Failed with result 'exit-code'.
Jan 14 16:14:14 srv2-node1 systemd[1]: Failed to start Bind mount or link /nix/store/8qi3dx1w9c1r2ngm542vcpz3a9mvydsh-user-files/home/chn/.bash_profile to /home/chn/.bash_profile.
```

This is because when `touch` a symlink, it updates the timestamp of the file or dir the symlink point to, but the pointed file or dir may not exist. Use `-h` to make it updates the timestamp of the symlink.