### PR TITLE
nixos: allow usernames different from NixOS' users.users attribute name

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -264,8 +264,8 @@ in
                         let
                           userDefaultPerms = {
                             inherit (defaultPerms) mode;
-                            user = name;
-                            group = users.${userDefaultPerms.user}.group;
+                            user = users.${name}.name;
+                            group = users.${name}.group;
                           };
                           fileConfig =
                             { config, ... }:
@@ -593,7 +593,7 @@ in
                           home = null;
                           mode = "0700";
                           user = dir.user;
-                          group = users.${dir.user}.group;
+                          group = dir.group;
                           inherit defaultPerms;
                           inherit (dir) persistentStoragePath enableDebugging;
                         };


### PR DESCRIPTION
A user with persistence defined in their home directory using the NixOS module currently requires to have the same username as their users.users attribute name.
This change fixes that by pulling not just the group but also the name from the NixOS config.