### PR TITLE
docs: improve `postResumeCommands` subvolume handling in `btrfs` documentation

### DIFF
--- a/README.org
+++ b/README.org
@@ -112,9 +112,9 @@
           mkdir /btrfs_tmp
           mount /dev/root_vg/root /btrfs_tmp
           if [[ -e /btrfs_tmp/root ]]; then
-              mkdir -p /btrfs_tmp/old_roots
+              mkdir -p /btrfs_tmp/persistent/old_roots
               timestamp=$(date --date="@$(stat -c %Y /btrfs_tmp/root)" "+%Y-%m-%-d_%H:%M:%S")
-              mv /btrfs_tmp/root "/btrfs_tmp/old_roots/$timestamp"
+              mv /btrfs_tmp/root "/btrfs_tmp/persistent/old_roots/$timestamp"
           fi
 
           delete_subvolume_recursively() {
@@ -125,7 +125,7 @@
               btrfs subvolume delete "$1"
           }
 
-          for i in $(find /btrfs_tmp/old_roots/ -maxdepth 1 -mtime +30); do
+          for i in $(find /btrfs_tmp/persistent/old_roots/ -mindepth 1 -maxdepth 1 -mtime +30); do
               delete_subvolume_recursively "$i"
           done
 


### PR DESCRIPTION
Hello,

The current documentation for the `postResumeCommands` using `btrfs` subvolumes isn't working properly, I made the following updates:

- Added `old_roots` folder in the persistent directory to fix folder accessibility
- Modified find command with `-mindepth 1` to exclude the parent folder

Also discussed in https://github.com/nix-community/impermanence/issues/258

Let me know what you think!