### PR TITLE
docs(README): Add guardrail against failed boots

### DIFF
--- a/README.org
+++ b/README.org
@@ -114,7 +114,11 @@
           if [[ -e /btrfs_tmp/root ]]; then
               mkdir -p /btrfs_tmp/old_roots
               timestamp=$(date --date="@$(stat -c %Y /btrfs_tmp/root)" "+%Y-%m-%-d_%H:%M:%S")
-              mv /btrfs_tmp/root "/btrfs_tmp/old_roots/$timestamp"
+              if [[ ! -e /btrfs_tmp/old_roots/$timestamp ]]; then
+                mv /btrfs_tmp/root "/btrfs_tmp/old_roots/$timestamp"
+              else
+                btrfs subvolume delete /btrfs_tmp/root
+              fi
           fi
 
           delete_subvolume_recursively() {


### PR DESCRIPTION
In the current snapshot moving logic, there's an edge case where if the root hasn't changed at all between two boots, the `old_roots/$timestamp` location will already exist, leading to an error upon `mv` and failed boots.

This fix guarantees idempotency by adding an if check and simply deletes the subvolume instead of moving it to backup location, if that particular backup already exists.