### PR TITLE
feat: `allowTrash` option

### DIFF
--- a/README.org
+++ b/README.org
@@ -254,6 +254,11 @@
         manager. If enabled, it sets the mount option ~x-gvfs-hide~
         on all the bind mounts.
 
+      - ~allowTrash~ allows you to specify whether to allow apps that use
+      certain GTK-based technologies such as GIO to put items in the
+      trash. If enabled, it sets the mount option ~x-gvfs-trash~ on all
+      the bind mounts.
+
 ****** ~directories~
 
        All directories you want to bind mount to persistent storage. A

--- a/nixos.nix
+++ b/nixos.nix
@@ -267,7 +267,7 @@ in
 
             boot.initrd.systemd.mounts =
               let
-                mkBindMount = { dirPath, persistentStoragePath, hideMount, ... }: {
+                mkBindMount = { dirPath, persistentStoragePath, hideMount, allowTrash, ... }: {
                   wantedBy = [ "initrd.target" ];
                   before = [ "initrd-nixos-activation.service" ];
                   where = concatPaths [ "/sysroot" dirPath ];
@@ -278,6 +278,8 @@ in
                     "bind"
                   ] ++ optionals hideMount [
                     "x-gvfs-hide"
+                  ] ++ optionals allowTrash [
+                    "x-gvfs-trash"
                   ]);
                 };
                 dirs = filter (d: elem d.dirPath pathsNeededForBoot) directories;
@@ -286,7 +288,7 @@ in
 
             systemd.mounts =
               let
-                mkBindMount = { dirPath, persistentStoragePath, hideMount, ... }: {
+                mkBindMount = { dirPath, persistentStoragePath, hideMount, allowTrash, ... }: {
                   wantedBy = [ "local-fs.target" ];
                   before = [ "local-fs.target" ];
                   where = concatPaths [ "/" dirPath ];
@@ -297,6 +299,8 @@ in
                     "bind"
                   ] ++ optionals hideMount [
                     "x-gvfs-hide"
+                  ] ++ optionals allowTrash [
+                    "x-gvfs-trash"
                   ]);
                 };
               in

--- a/submodule-options.nix
+++ b/submodule-options.nix
@@ -157,6 +157,15 @@ let
           mounted drives.
         '';
       };
+      allowTrash = mkOption {
+        type = bool;
+        default = config.allowTrash;
+        defaultText = "environment.persistence.‹name›.allowTrash";
+        example = true;
+        description = ''
+          Whether to allow newer GIO-based applications to trash files.
+        '';
+      };
       # Save the default permissions at the level the
       # directory resides. This used when creating its
       # parent directories, giving them reasonable
@@ -292,6 +301,15 @@ in
           example = true;
           description = ''
             Whether to hide bind mounts from showing up as mounted drives.
+          '';
+        };
+
+        allowTrash = mkOption {
+          type = bool;
+          default = false;
+          example = true;
+          description = ''
+            Whether to allow newer GIO-based applications to trash files.
           '';
         };
 


### PR DESCRIPTION
supercedes #243, adapted for the #272 changes. i have been running a fork with both of these patches applied for a while, was just waiting for #272 to be merged.