### PR TITLE
Fix: Parent directories are owned by root/root instead of <user>/users when using home.persistence

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -397,7 +397,9 @@ in
                               persistentStoragePath = "";
                               home = null;
                               inherit (dir) defaultPerms enableDebugging;
-                              inherit (dir.defaultPerms) user group mode;
+                              inherit (dir.defaultPerms) mode;
+                              user = if dir.home != null then dir.user else dir.defaultPerms.user;
+                              group = if dir.home != null then dir.group else dir.defaultPerms.group;
                             };
                           in
                           if dir.home == null && !(elem persistentStorageDir state) then
@@ -425,7 +427,9 @@ in
                             else
                               path;
                           inherit (dir) persistentStoragePath home enableDebugging;
-                          inherit (dir.defaultPerms) user group mode;
+                          inherit (dir.defaultPerms) mode;
+                          user = if dir.home != null then dir.user else dir.defaultPerms.user;
+                          group = if dir.home != null then dir.group else dir.defaultPerms.group;
                         };
                         # Create new directory items for all parent
                         # directories of a directory.


### PR DESCRIPTION
Basically seems to fix issue: https://github.com/nix-community/impermanence/issues/298, which makes a load of apps, etc break because folders like .cache, .local, and whatever contains persisted files/folders in home becomes owned by root. This is a very annoying issue as every time I rebuild, it makes .local, etc owned by root.