### PR TITLE
regression: Do not treat `/` as a "home"

### DIFF
--- a/submodule-options.nix
+++ b/submodule-options.nix
@@ -187,16 +187,16 @@ let
     }
     ({ config, ... }:
       let
-        home = if config.home != null then config.home else "/";
+        parentPath = if config.home != null then config.home else "/";
         directory = dirOf config.file;
       in
       {
         parentDirectory = {
-          dirPath = concatPaths [ home directory ];
-          inherit directory defaultPerms home;
-          inherit (config) persistentStoragePath;
+          dirPath = concatPaths [ parentPath directory ];
+          inherit directory defaultPerms;
+          inherit (config) home persistentStoragePath;
         };
-        filePath = concatPaths [ home config.file ];
+        filePath = concatPaths [ parentPath config.file ];
       })
   ];
   dir = submodule ([


### PR DESCRIPTION
`parentDirectory.home` was set to `/` for non-HM managed files which caused `/` to be given 0700 permissions. This made certain systemd units running as non-root uncapable of accessing the filesystem and at worst rendering the machine unbootable.