### PR TITLE
fix bug: use numeric UID/GID for directory ownership in initrd where usernames don't resolve

### DIFF
--- a/create-directories.bash
+++ b/create-directories.bash
@@ -28,8 +28,10 @@ trap 'echo Error when executing ${BASH_COMMAND} at line ${LINENO}! >&2' ERR
 #   3. Copy the mode of the source path to the target path
 
 # Get inputs from command line arguments
-if [[ $# != 6 ]]; then
-    printf "Error: 'create-directories.bash' requires *six* args.\n" >&2
+# Arguments: sourceBase target user group mode debug [uid gid]
+# uid and gid are optional numeric IDs (required for initrd where usernames don't resolve)
+if [[ $# -lt 6 ]]; then
+    printf "Error: 'create-directories.bash' requires at least six args.\n" >&2
     exit 1
 fi
 sourceBase="$1"
@@ -38,10 +40,33 @@ user="$3"
 group="$4"
 mode="$5"
 debug="$6"
+uid="${7:-}"
+gid="${8:-}"
 
 if (( debug )); then
     set -o xtrace
 fi
+
+# Check if user exists (may not in initrd environment)
+# Returns 0 if user exists, 1 otherwise
+user_exists() {
+    id "$1" >/dev/null 2>&1
+}
+
+# Set ownership using either numeric UID/GID or username/group
+# In initrd, usernames don't resolve, so numeric IDs are required
+set_ownership() {
+    local dir="$1"
+    local owner
+    if [[ -n "$uid" && -n "$gid" ]] && ! user_exists "$user"; then
+        # In initrd or if user doesn't exist, use numeric IDs
+        owner="${uid}:${gid}"
+    else
+        # In main system with user database, use username/group
+        owner="${user}:${group}"
+    fi
+    chown "$owner" "$dir"
+}
 
 # check that the source exists and warn the user if it doesn't, then
 # create them with the specified permissions
@@ -49,7 +74,22 @@ realSource="$(realpath -m "$sourceBase$target")"
 if [[ ! -d $realSource ]]; then
     printf "Warning: Source directory '%s' does not exist; it will be created for you with the following permissions: owner: '%s:%s', mode: '%s'.\n" "$realSource" "$user" "$group" "$mode"
     mkdir --mode="$mode" "$realSource"
-    chown "$user:$group" "$realSource"
+    set_ownership "$realSource"
+else
+    # Fix ownership if it was created incorrectly (e.g., during nixos-install)
+    # Compare using numeric IDs since in initrd usernames show as UNKNOWN
+    current_uid=$(stat -c '%u' "$realSource")
+    current_gid=$(stat -c '%g' "$realSource")
+    desired_uid="${uid:-}"
+    desired_gid="${gid:-}"
+
+    # Only try to fix if we have the desired uid/gid and they differ
+    if [[ -n "$desired_uid" && -n "$desired_gid" ]]; then
+        if [[ "$current_uid" != "$desired_uid" || "$current_gid" != "$desired_gid" ]]; then
+            printf "Fixing ownership of '%s' from uid=%s:gid=%s to %s:%s\n" "$realSource" "$current_uid" "$current_gid" "$desired_uid" "$desired_gid"
+            chown "${desired_uid}:${desired_gid}" "$realSource"
+        fi
+    fi
 fi
 
 if [[ $sourceBase ]]; then

--- a/nixos.nix
+++ b/nixos.nix
@@ -85,6 +85,43 @@ let
 
   inherit (allPersistentStoragePaths) files directories;
 
+  defaultPerms = {
+    mode = "0755";
+    user = "root";
+    group = "root";
+  };
+
+  # The parent directories of files (for ownership/permissions)
+  fileDirs = unique (catAttrs "parentDirectory" files);
+  # All the directories actually listed by the user and the parent directories of listed files
+  explicitDirs = directories ++ fileDirs;
+  # Home directories have to be handled specially (for permissions)
+  homeDirs =
+    foldl'
+      (state: dir:
+        let
+          homeDir = {
+            directory = dir.home;
+            dirPath = dir.home;
+            home = null;
+            mode = "0700";
+            user = dir.user;
+            group = users.${dir.user}.group;
+            inherit defaultPerms;
+            inherit (dir) persistentStoragePath enableDebugging;
+          };
+        in
+        if dir.home != null then
+          if !(elem homeDir state) then
+            state ++ [ homeDir ]
+          else
+            state
+        else
+          state
+      )
+      [ ]
+      explicitDirs;
+
   mountFile = pkgs.runCommand "persistence-mount-file" { buildInputs = [ pkgs.bash ]; } ''
     cp ${./mount-file.bash} $out
     patchShebangs $out
@@ -104,12 +141,6 @@ let
     ''
       ${mountFile} ${args}
     '';
-
-  defaultPerms = {
-    mode = "0755";
-    user = "root";
-    group = "root";
-  };
 in
 {
   options = {
@@ -327,65 +358,27 @@ in
                   , ...
                   }:
                   let
-                    args = [
+                    groupName = if group == null then users.${user}.group else group;
+                    uid = users.${user}.uid;
+                    gid = config.users.groups.${groupName}.gid;
+                  in
+                  ''
+                    ${createDirectories} ${escapeShellArgs [
                       persistentStoragePath
                       dirPath
                       user
-                      # Home Manager doesn't seem to know about the user's group
-                      (if group == null then users.${user}.group else group)
+                      groupName
                       mode
                       enableDebugging
-                    ];
-                  in
-                  ''
-                    ${createDirectories} ${escapeShellArgs args}
+                      (if uid == null then "" else toString uid)
+                      (if gid == null then "" else toString gid)
+                    ]}
                   '';
 
                 # Build an activation script which creates all persistent
                 # storage directories we want to bind mount.
                 dirCreationScript =
                   let
-                    # The parent directories of files.
-                    fileDirs = unique (catAttrs "parentDirectory" files);
-
-                    # All the directories actually listed by the user and the
-                    # parent directories of listed files.
-                    explicitDirs = directories ++ fileDirs;
-
-                    # Home directories have to be handled specially, since
-                    # they're at the permissions boundary where they
-                    # themselves should be owned by the user and have stricter
-                    # permissions than regular directories, whereas its parent
-                    # should be owned by root and have regular permissions.
-                    #
-                    # This simply collects all the home directories and sets
-                    # the appropriate permissions and ownership.
-                    homeDirs =
-                      foldl'
-                        (state: dir:
-                          let
-                            homeDir = {
-                              directory = dir.home;
-                              dirPath = dir.home;
-                              home = null;
-                              mode = "0700";
-                              user = dir.user;
-                              group = users.${dir.user}.group;
-                              inherit defaultPerms;
-                              inherit (dir) persistentStoragePath enableDebugging;
-                            };
-                          in
-                          if dir.home != null then
-                            if !(elem homeDir state) then
-                              state ++ [ homeDir ]
-                            else
-                              state
-                          else
-                            state
-                        )
-                        [ ]
-                        explicitDirs;
-
                     # Persistent storage directories. These need to be created
                     # unless they're at the root of a filesystem.
                     persistentStorageDirs =
@@ -455,6 +448,11 @@ in
                       ++ explicitDirs;
                   in
                   pkgs.writeShellScript "persistence-run-create-directories" ''
+                    # Skip during nixos-install - users don't exist in chroot
+                    if [ -n "''${NIXOS_INSTALL_BOOTLOADER:-}" ]; then
+                      exit 0
+                    fi
+
                     _status=0
                     trap "_status=1" ERR
                     ${concatMapStrings mkDirWithPerms allDirs}
@@ -463,6 +461,11 @@ in
 
                 persistFileScript =
                   pkgs.writeShellScript "persistence-persist-files" ''
+                    # Skip during nixos-install - users don't exist in chroot
+                    if [ -n "''${NIXOS_INSTALL_BOOTLOADER:-}" ]; then
+                      exit 0
+                    fi
+
                     _status=0
                     trap "_status=1" ERR
                     ${concatMapStrings mkPersistFile files}
@@ -588,6 +591,39 @@ in
                         times:
                           ${concatStringsSep "\n      " duplicateDirs}
                   '';
+                }
+                {
+                  # When using systemd initrd, activation scripts run in initrd
+                  # where /etc/passwd doesn't have regular users. We need
+                  # numeric uid/gid to set ownership correctly.
+                  assertion =
+                    let
+                      # Get all users referenced in persistence config with home directories
+                      userDirs = filter (d: d.home != null) explicitDirs;
+                      # Check if any persisted user dirs have users without uid
+                      offenders = filter (dir: users.${dir.user}.uid == null) userDirs;
+                      usingInitrdSystemd = config.boot.initrd.systemd.enable or false;
+                    in
+                    !usingInitrdSystemd || offenders == [ ];
+                  message =
+                    let
+                      userDirs = filter (d: d.home != null) explicitDirs;
+                      offenders = filter (dir: users.${dir.user}.uid == null) userDirs;
+                    in
+                    ''
+                      environment.persistence:
+                          When using systemd initrd (boot.initrd.systemd.enable = true),
+                          users with persistent home directories must have a uid set.
+                          This is required because activation scripts run in initrd where
+                          usernames cannot be resolved.
+                          
+                          Please set a uid for the following users:
+                            ${concatStringsSep "\n      " (map (d: d.user) (unique offenders))}
+                          
+                          Example:
+                            users.users.myuser.uid = 1000;
+                            users.groups.mygroup.gid = 1000;
+                    '';
                 }
               ];
 


### PR DESCRIPTION
## Problem

When using `boot.initrd.systemd.enable = true`, activation scripts run in the initrd environment where `/etc/passwd` doesn't contain regular users. This causes `create-directories.bash` to fail when trying to set ownership with usernames like `chown user:group /path`, resulting in directories being created with `root:root` ownership instead of the correct user ownership.

This is particularly problematic for persistent home directories which are bind-mounted early in boot and need correct ownership for the user to access their files.

Note that this happens with both home-manager and nixos module, for all non-root users, when `initrd.systemd` is enabled.

Relevant sections in nix config:
```nix
{
  # Core disks - enables initrd systemd for encrypted root
  boot.initrd.systemd = {
    enable = true;  # Required for LUKS + TPM2/FIDO2
    fido2.enable = true;  # or tpm2.enable
  };

  fileSystems."/persistent-root".neededForBoot = true;
  fileSystems."/persistent-home".neededForBoot = true;
  fileSystems."/home".neededForBoot = true;

  boot.initrd = {
    supportedFilesystems = ["btrfs"];
    postResumeCommands = mkIf (!systemdInitrd) (mkAfter wipeScript);
    systemd = mkIf systemdInitrd {
      services.impermanence-wipe = {
        description = "Wipe root and home btrfs subvolumes for impermanence";
        wantedBy = ["initrd.target"];
        after = ["cryptsetup.target"];
        before = ["sysroot.mount"];
        unitConfig.DefaultDependencies = false;
        serviceConfig.Type = "oneshot";
        script = wipeScript;
      };
    };
  };

  environment.persistence."/persistent-root" = {
    hideMounts = true;
    allowTrash = true;
    files = defaultFiles ++ cfg.files;
    directories = defaultDirectories ++ cfg.directories;
  };

  home-manager.sharedModules = [
    ({config, ...}: {
      home.persistence."/persistent-home" = {
        enable = true;
        files = defaultUserFiles ++ cfg.userFiles;
        directories = defaultUserDirectories ++ cfg.userDirectories;
      };
    })
  ];

  # User management with userborn
  services.userborn.enable = true; 
  
  users.users.krumpy-miha = {
    isNormalUser = true;
    uid = 1000;  # Now required with systemd initrd + persistent home
  };
  users.groups."users".gid = 100;
}
```

I discovered the issue when I tried to make the directory creation script automatically fix the wrong user:group ownership. 

[journalctl-default.log](https://github.com/user-attachments/files/26165649/journalctl-default.log)

The relevant section from journalctl clearly shows that it tries to chown without the users even being available (they are created/available later in boot process).

## Solution

Pass numeric UID/GID to the directory creation script and use them for `chown` operations when usernames cannot be resolved:

1. **Pass UID/GID to create-directories.bash**: The script now accepts optional `uid` and `gid` arguments
2. **Ownership handling**: 
   - In initrd: Use numeric `chown uid:gid` when the user doesn't exist
   - In main system: Use `chown user:group` when the user database is available
3. **Fix existing directories**: On subsequent boots, correct ownership using numeric ID comparison
4. **Build-time assertion**: When `boot.initrd.systemd.enable = true`, require that users with persistent home directories have explicit `uid`/`gid` set

Relevant section in journalctl that shows that the solution is working:

[journalctl-with-solution.log](https://github.com/user-attachments/files/26165651/journalctl-with-solution.log)

## Changes

- `nixos.nix`: Pass uid/gid to create-directories.bash, add assertion for initrd systemd users
- `create-directories.bash`: Accept uid/gid args, use numeric IDs when usernames don't resolve
- Skip activation during `nixos-install` (users don't exist in chroot anyway)

## Requirements for users

When using `boot.initrd.systemd.enable = true` with persistent home directories, users must now set explicit uid/gid:

```nix
users.users.myuser.uid = 1000;
users.groups.mygroup.gid = 1000;
```

An assertion error is shown if this is forgotten.

## Additional notes

While I did search the issues and pull request, none seem to mention this specific problem. If this fix is unnecessary, and I simply did something wrong in the config, please correct me.

I also added code that will fix the permissions if they got set wrong, but it is not really necessary, unless they got set wrong before.

Both journalctl logs are from first boot on completely fresh nixos system (used disko and nixos-install). I did not test with `initrd.systemd` disabled, since I currently use all system drives encrypted only (`initrd.systemd` has to be enabled therefore).