### PR TITLE
nixos: refer to real os name of the user

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -142,7 +142,7 @@ in
                             config = outerConfig // config;
                             name = outerName;
                             usersOpts = true;
-                            user = name;
+                            user = users.${name}.name;
                             group = users.${name}.group;
                             homeDir = users.${name}.home;
                           }
@@ -369,10 +369,8 @@ in
                               dirPath = dir.home;
                               home = null;
                               mode = "0700";
-                              user = dir.user;
-                              group = users.${dir.user}.group;
                               inherit defaultPerms;
-                              inherit (dir) persistentStoragePath enableDebugging;
+                              inherit (dir) user group persistentStoragePath enableDebugging;
                             };
                           in
                           if dir.home != null then


### PR DESCRIPTION
The name passed in via `environment.persistence.<root>.users.<name>` is expected to match `users.users.<name>`. However, that may not be the actual username of the user known to the OS if `users.users.<name>.name` is set to something else.

As an example, without this PR, if I have impermanence create a directory in my home directory, it fails to `chown` with the following:
```
Warning: Source directory '/persist/home/getpsyched/foo' does not exist; it will be created for you with the following permissions: owner: 'primary:users', mode: '0755'.
chown: invalid user: ‘primary:users’
Error when executing chown "$user:$group" "$realSource" at line 52!
Activation script snippet 'createPersistentStorageDirs' failed (1)
```

It tries to `chown` to the `primary` user which doesn't exist since that's the name in my config, not on Linux.

After this change, it correctly does the `chown`:
```
Warning: Source directory '/persist/home/getpsyched/foo' does not exist; it will be created for you with the following permissions: owner: 'getpsyched:users', mode: '0755'.
```