### PR TITLE
Add an Option purgeUndeclaredFiles

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -496,9 +496,14 @@ in
                     pureDirs = unique (sysDirs ++ usersDirs ++ hmDirs);
                     pureFiles = unique (sysFiles ++ usersFiles ++ hmFiles);
                     pureParents = unique (concatMap parentsOf (pureDirs ++ pureFiles));
+                    allPaths = pureDirs ++ pureFiles ++ pureParents;
+                    sortedPath = builtins.sort (a: b: a < b) allPaths;
+
+                    configManifest = concatStringsSep "\n" sortedPath;
+                    currentConfigHash = builtins.hashString "sha256" configManifest;
 
                     debugArg = if v.enableDebugging then "1" else "0";
-                    args = [ base debugArg ] ++ [ "--dirs" ] ++ pureDirs ++ [ "--files" ] ++ pureFiles ++ [ "--parents" ] ++ pureParents;
+                    args = [ base debugArg currentConfigHash ] ++ [ "--dirs" ] ++ pureDirs ++ [ "--files" ] ++ pureFiles ++ [ "--parents" ] ++ pureParents;
                   in
                     ''
                     ${purgeUndeclaredScript} ${escapeShellArgs args}

--- a/nixos.nix
+++ b/nixos.nix
@@ -468,15 +468,47 @@ in
                     ${concatMapStrings mkPersistFile files}
                     exit $_status
                   '';
+
+                purgeUndeclaredScript = pkgs.runCommand "persistence-purge-undeclared" { buildInputs = [ pkgs.bash ]; } ''
+                  cp ${./purge-undeclared.bash} $out
+                  patchShebangs $out
+                '';
+
+                purgeConfigs = filterAttrs (_: v: v.purageUndeclaredFiles && v.enable) cfg;
+
+                mkPurgeCmdForBlock = name: v:
+                  let
+                    base = v.persistentStoragePath;
+
+                    sysDirs = map (d: concatPaths [ base d.dirPath ]) v.directories;
+                    sysFiles = map (f: concatPaths [base f.filePath ]) v.files;
+
+                    usersDirs = concatMap (u: map (d: concatPaths [ base d.dirPath ]) u.directories) (attrValues v.users);
+                    usersFiles = concatMap (u: map (f: concatPaths [ base f.filePath ]) u.files) (attrValues v.users);
+
+                    allExplicitPaths = sysDirs ++ sysFiles ++ usersDirs ++ usersFiles;
+                    allAllowedPaths = unique (allExplicitPaths ++ concatMap parentsOf allExplicitPaths);
+
+                    debugArg = if v.enableDebugging then "1" else "0";
+                    args = [ base debugArg ] ++ allAllowedPaths;
+                  in
+                    ''
+                    ${purgeUndeclaredScript} ${escapeShellArgs args}
+                    '';
+                purgeScript = concatMapStrings (name: mkPurgeCmdForBlock name cfg.${name}) (attrNames purgeConfigs);
               in
               {
                 "createPersistentStorageDirs" = {
-                  deps = [ "users" "groups" ];
+                  deps = [ "users" "groups" "purgeUndeclaredFiles" ];
                   text = "${dirCreationScript}";
                 };
                 "persist-files" = {
                   deps = [ "createPersistentStorageDirs" ];
                   text = "${persistFileScript}";
+                };
+                "purgeUndeclaredFiles" = {
+                  deps = [ "users" "groups" ];
+                  text = purgeScript;
                 };
               };
 

--- a/nixos.nix
+++ b/nixos.nix
@@ -498,7 +498,7 @@ in
                     pureParents = unique (concatMap parentsOf (pureDirs ++ pureFiles));
 
                     debugArg = if v.enableDebugging then "1" else "0";
-                    args = [ base debugArg ] ++ [ "--dirs" ] ++ pureDirs ++ [ "files" ] ++ pureFiles ++ [ "--parents" ] ++ pureParents;
+                    args = [ base debugArg ] ++ [ "--dirs" ] ++ pureDirs ++ [ "--files" ] ++ pureFiles ++ [ "--parents" ] ++ pureParents;
                   in
                     ''
                     ${purgeUndeclaredScript} ${escapeShellArgs args}

--- a/nixos.nix
+++ b/nixos.nix
@@ -479,17 +479,17 @@ in
                 mkPurgeCmdForBlock = name: v:
                   let
                     base = v.persistentStoragePath;
-                    
-                    hmConfigsForBlock = filter (hmCfg: hmCfg.persistentStoragePath == base ) (
-                      flatten (mapAttrsToList (_name: value: attrValues (value.home.persistence or {})) config.home-manager.users or {})
+
+                    hmConfigsForBlock = filter (hmCfg: hmCfg.persistentStoragePath == base) (
+                      flatten (mapAttrsToList (_name: value: attrValues (value.home.persistence or { })) config.home-manager.users or { })
                     );
 
                     sysDirs = map (d: concatPaths [ base d.dirPath ]) v.directories;
-                    sysFiles = map (f: concatPaths [base f.filePath ]) v.files;
+                    sysFiles = map (f: concatPaths [ base f.filePath ]) v.files;
 
                     usersDirs = concatMap (u: map (d: concatPaths [ base d.dirPath ]) u.directories) (attrValues v.users);
                     usersFiles = concatMap (u: map (f: concatPaths [ base f.filePath ]) u.files) (attrValues v.users);
-                    
+
                     hmDirs = concatMap (hm: map (d: concatPaths [ base d.dirPath ]) hm.directories) hmConfigsForBlock;
                     hmFiles = concatMap (hm: map (f: concatPaths [ base f.filePath ]) hm.files) hmConfigsForBlock;
 
@@ -500,9 +500,9 @@ in
                     debugArg = if v.enableDebugging then "1" else "0";
                     args = [ base debugArg ] ++ [ "--dirs" ] ++ pureDirs ++ [ "--files" ] ++ pureFiles ++ [ "--parents" ] ++ pureParents;
                   in
-                    ''
+                  ''
                     ${purgeUndeclaredScript} ${escapeShellArgs args}
-                    '';
+                  '';
                 purgeScript = concatMapStrings (name: mkPurgeCmdForBlock name cfg.${name}) (attrNames purgeConfigs);
               in
               {

--- a/nixos.nix
+++ b/nixos.nix
@@ -474,7 +474,7 @@ in
                   patchShebangs $out
                 '';
 
-                purgeConfigs = filterAttrs (_: v: v.purageUndeclaredFiles && v.enable) cfg;
+                purgeConfigs = filterAttrs (_: v: v.purgeUndeclaredFiles && v.enable) cfg;
 
                 mkPurgeCmdForBlock = name: v:
                   let

--- a/nixos.nix
+++ b/nixos.nix
@@ -496,14 +496,9 @@ in
                     pureDirs = unique (sysDirs ++ usersDirs ++ hmDirs);
                     pureFiles = unique (sysFiles ++ usersFiles ++ hmFiles);
                     pureParents = unique (concatMap parentsOf (pureDirs ++ pureFiles));
-                    allPaths = pureDirs ++ pureFiles ++ pureParents;
-                    sortedPath = builtins.sort (a: b: a < b) allPaths;
-
-                    configManifest = concatStringsSep "\n" sortedPath;
-                    currentConfigHash = builtins.hashString "sha256" configManifest;
 
                     debugArg = if v.enableDebugging then "1" else "0";
-                    args = [ base debugArg currentConfigHash ] ++ [ "--dirs" ] ++ pureDirs ++ [ "--files" ] ++ pureFiles ++ [ "--parents" ] ++ pureParents;
+                    args = [ base debugArg ] ++ [ "--dirs" ] ++ pureDirs ++ [ "--files" ] ++ pureFiles ++ [ "--parents" ] ++ pureParents;
                   in
                     ''
                     ${purgeUndeclaredScript} ${escapeShellArgs args}

--- a/nixos.nix
+++ b/nixos.nix
@@ -479,18 +479,26 @@ in
                 mkPurgeCmdForBlock = name: v:
                   let
                     base = v.persistentStoragePath;
+                    
+                    hmConfigsForBlock = filter (hmCfg: hmCfg.persistentStoragePath == base ) (
+                      flatten (mapAttrsToList (_name: value: attrValues (value.home.persistence or {})) config.home-manager.users or {})
+                    );
 
                     sysDirs = map (d: concatPaths [ base d.dirPath ]) v.directories;
                     sysFiles = map (f: concatPaths [base f.filePath ]) v.files;
 
                     usersDirs = concatMap (u: map (d: concatPaths [ base d.dirPath ]) u.directories) (attrValues v.users);
                     usersFiles = concatMap (u: map (f: concatPaths [ base f.filePath ]) u.files) (attrValues v.users);
+                    
+                    hmDirs = concatMap (hm: map (d: concatPaths [ base d.dirPath ]) hm.directories) hmConfigsForBlock;
+                    hmFiles = concatMap (hm: map (f: concatPaths [ base f.filePath ]) hm.files) hmConfigsForBlock;
 
-                    allExplicitPaths = sysDirs ++ sysFiles ++ usersDirs ++ usersFiles;
-                    allAllowedPaths = unique (allExplicitPaths ++ concatMap parentsOf allExplicitPaths);
+                    pureDirs = unique (sysDirs ++ usersDirs ++ hmDirs);
+                    pureFiles = unique (sysFiles ++ usersFiles ++ hmFiles);
+                    pureParents = unique (concatMap parentsOf (pureDirs ++ pureFiles));
 
                     debugArg = if v.enableDebugging then "1" else "0";
-                    args = [ base debugArg ] ++ allAllowedPaths;
+                    args = [ base debugArg ] ++ [ "--dirs" ] ++ pureDirs ++ [ "files" ] ++ pureFiles ++ [ "--parents" ] ++ pureParents;
                   in
                     ''
                     ${purgeUndeclaredScript} ${escapeShellArgs args}

--- a/purge-undeclared.bash
+++ b/purge-undeclared.bash
@@ -5,6 +5,7 @@ set -o errexit            # Exit on command failure.
 set -o pipefail           # Exit on failure of any command in a pipeline.
 set -o errtrace           # Trap errors in functions and subshells.
 shopt -s inherit_errexit  # Inherit the errexit option status in subshells.
+shopt -s nullglob dotglob
 
 trap 'echo Error when executing ${BASH_COMMAND} at line ${LINENO}! >&2' ERR
 
@@ -28,21 +29,45 @@ fi
 echo "Impermanence: Purging undeclared files and directories in $baseDir..."
 
 declare -A allowed_paths
-allowed_paths["$baseDir"]=1
 
-for path in "$@"; do
-  allowed_paths["$path"]=1
-done
-
-while IFS= read -r -d $'\0' item; do
-  if [[ "$item" == "$baseDir" ]]; then
+current_type=""
+for arg in "$@"; do
+  if [[ "$arg" == "--dirs" || "$arg" == "--files" || "$arg" == "--parents" ]]; then
+    current_type="${arg#--}"
     continue
   fi
-  
-  if [[ -z "${allowed_paths["$item"]:-}" ]]; then
-    if (( debug )); then 
-      echo "Removing undeclared path: $item"
+  if [[ -n "$current_type" ]]; then
+    if [[ "${allowed_paths[$arg]:-}" != "dirs" ]]; then
+      allowed_paths["$arg"]="$current_type"
     fi
-    #rm -rf "$item"
   fi
-done < <(find "$baseDir" -depth -mindepth 1 -print0)
+
+done
+purge_tree() {
+  local parent="$1"
+  local item
+
+  for item in "$parent"/*; do
+    [[ "${item##*/}" == "." || "${item##*/}" == ".." ]] && continue
+
+    case "${allowed_paths[$item]:-}" in
+      "dirs")
+        continue
+        ;;
+      "files")
+        continue
+        ;;
+      "parents")
+        purge_tree "$item"
+        ;;
+      *)
+        if (( debug )); then
+          echo "Removing undeclared path: $item"
+        fi
+        # rm -rf "$item"
+        ;;
+    esac
+  done
+}
+
+purge_tree "$baseDir"

--- a/purge-undeclared.bash
+++ b/purge-undeclared.bash
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -o nounset            # Fail on use of unset variable.
+set -o errexit            # Exit on command failure.
+set -o pipefail           # Exit on failure of any command in a pipeline.
+set -o errtrace           # Trap errors in functions and subshells.
+shopt -s inherit_errexit  # Inherit the errexit option status in subshells.
+
+trap 'echo Error when executing ${BASH_COMMAND} at line ${LINENO}! >&2' ERR
+
+if [[ $# -lt 2 ]]; then
+  echo "Error: 'purge-undeclared.bash' requires at least two args: baseDir and debug." >&2
+  exit 1
+fi
+
+baseDir="$1"
+debug="$2"
+shift 2
+
+if (( debug )); then
+  set -o xtrace
+fi
+
+if [[ ! -d "$baseDir" ]]; then
+  exit 0
+fi
+
+echo "Impermanence: Purging undeclared files and directories in $baseDir..."
+
+declare -A allowed_paths
+allowed_paths["$baseDir"]=1
+
+for path in "$@"; do
+  allowed_paths["$path"]=1
+done
+
+while IFS= read -r -d $'\0' item; do
+  if [[ "$item" == "$baseDir" ]]; then
+    continue
+  fi
+  
+  if [[ -z "${allowed_paths["$item"]:-}" ]]; then
+    if (( debug )); then 
+      echo "Removing undeclared path: $item"
+    fi
+    #rm -rf "$item"
+  fi
+done < <(find "$baseDir" -depth -mindepth 1 -print0)

--- a/purge-undeclared.bash
+++ b/purge-undeclared.bash
@@ -10,16 +10,13 @@ shopt -s nullglob dotglob
 trap 'echo Error when executing ${BASH_COMMAND} at line ${LINENO}! >&2' ERR
 
 if [[ $# -lt 3 ]]; then
-  echo "Error: 'purge-undeclared.bash' requires at least three args: baseDir,debug,currentConfigHash ." >&2
+  echo "Error: 'purge-undeclared.bash' requires at least 2 args: baseDir,debug." >&2
   exit 1
 fi
 
 baseDir="$1"
 debug="$2"
-currentConfigHash="$3"
-shift 3
-
-lockFile="${baseDir}/.impermanence-purge-cache.lock"
+shift 2
 
 if (( debug )); then
   set -o xtrace
@@ -27,16 +24,6 @@ fi
 
 if [[ ! -d "$baseDir" ]]; then
   exit 0
-fi
-
-if [[ -f "$lockFile" ]]; then
-  read -r lastHash < "$lockFile"
-  if [[ "$lastHash" == "$currentConfigHash" ]]; then
-    if (( debug )); then
-      echo "Impermanence: Configuration unchanged. Skipping purge."
-    fi
-    exit 0
-  fi
 fi
 
 echo "Impermanence: Purging undeclared files and directories in $baseDir..."
@@ -81,4 +68,3 @@ purge_tree() {
 }
 
 purge_tree "$baseDir"
-echo "$currentConfigHash" > "$lockFile"

--- a/purge-undeclared.bash
+++ b/purge-undeclared.bash
@@ -75,7 +75,7 @@ purge_tree() {
         if (( debug )); then
           echo "Removing undeclared path: $item"
         fi
-        # rm -rf "$item"
+        rm -rf "$item"
       fi
   done
 }

--- a/purge-undeclared.bash
+++ b/purge-undeclared.bash
@@ -9,14 +9,17 @@ shopt -s nullglob dotglob
 
 trap 'echo Error when executing ${BASH_COMMAND} at line ${LINENO}! >&2' ERR
 
-if [[ $# -lt 2 ]]; then
-  echo "Error: 'purge-undeclared.bash' requires at least two args: baseDir and debug." >&2
+if [[ $# -lt 3 ]]; then
+  echo "Error: 'purge-undeclared.bash' requires at least three args: baseDir,debug,currentConfigHash ." >&2
   exit 1
 fi
 
 baseDir="$1"
 debug="$2"
-shift 2
+currentConfigHash="$3"
+shift 3
+
+lockFile="${baseDir}/.impermanence-purge-cache.lock"
 
 if (( debug )); then
   set -o xtrace
@@ -24,6 +27,16 @@ fi
 
 if [[ ! -d "$baseDir" ]]; then
   exit 0
+fi
+
+if [[ -f "$lockFile" ]]; then
+  read -r lastHash < "$lockFile"
+  if [[ "$lastHash" == "$currentConfigHash" ]]; then
+    if (( debug )); then
+      echo "Impermanence: Configuration unchanged. Skipping purge."
+    fi
+    exit 0
+  fi
 fi
 
 echo "Impermanence: Purging undeclared files and directories in $baseDir..."
@@ -41,33 +54,31 @@ for arg in "$@"; do
       allowed_paths["$arg"]="$current_type"
     fi
   fi
-
 done
+
 purge_tree() {
   local parent="$1"
   local item
+  local res
 
   for item in "$parent"/*; do
     [[ "${item##*/}" == "." || "${item##*/}" == ".." ]] && continue
 
-    case "${allowed_paths[$item]:-}" in
-      "dirs")
+    res="${allowed_paths[$item]:-}"
+    if [[ "$res" == "dirs" ]]; then
+      continue
+    elif [[ "$res" == "files" ]]; then
         continue
-        ;;
-      "files")
-        continue
-        ;;
-      "parents")
+    elif [[ "$res" == "parents" ]]; then
         purge_tree "$item"
-        ;;
-      *)
+    else
         if (( debug )); then
           echo "Removing undeclared path: $item"
         fi
         # rm -rf "$item"
-        ;;
-    esac
+      fi
   done
 }
 
 purge_tree "$baseDir"
+echo "$currentConfigHash" > "$lockFile"

--- a/purge-undeclared.bash
+++ b/purge-undeclared.bash
@@ -55,15 +55,15 @@ purge_tree() {
     if [[ "$res" == "dirs" ]]; then
       continue
     elif [[ "$res" == "files" ]]; then
-        continue
+      continue
     elif [[ "$res" == "parents" ]]; then
-        purge_tree "$item"
+      purge_tree "$item"
     else
-        if (( debug )); then
-          echo "Removing undeclared path: $item"
-        fi
-        rm -rf "$item"
+      if (( debug )); then
+        echo "Removing undeclared path: $item"
       fi
+      rm -rf "$item"
+    fi
   done
 }
 

--- a/submodule-options.nix
+++ b/submodule-options.nix
@@ -317,6 +317,15 @@ in
           '';
         };
 
+        purgeUndeclaredFiles = mkOption {
+          type = bool;
+          default = false;
+          description = ''
+            Whether to automatically remove files and directories within the persistent
+            storage path that are not explicitly specified in the configuration.
+          '';
+        };
+
         allowTrash = mkOption {
           type = bool;
           default = false;


### PR DESCRIPTION
Add an Option at `environment.persistence.<name>.purgeUndeclaredFiles`
Allowing for the automatic removal of files and directories within the persistent storage path that are not explicitly managed by the configuration.