### PR TITLE
lib: Clamp take count

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -12,6 +12,7 @@ let
     take
     length
     last
+    max
     ;
 
   # ["/home/user/" "/.screenrc"] -> ["home" "user" ".screenrc"]
@@ -36,7 +37,7 @@ let
     let
       prefix = optionalString (hasPrefix "/" path) "/";
       split = splitPath [ path ];
-      parents = take ((length split) - 1) split;
+      parents = take (max 0 ((length split) - 1)) split;
     in
     foldl'
       (state: item:


### PR DESCRIPTION
[097288c](https://github.com/NixOS/nixpkgs/commit/097288c) fixed a "bug" in lib.take in nixpkgs that allowed negative counts. Was `lib.take (-1) [] --> []` now `lib.take (-1) [] --> error: cannot create list of size -1`. The count could be negative if a file/directory was persisted directly under root, e.g. `/foo` because: 
```nix
split = splitPath [ "/" ]  # --> []  (only empty segments, all filtered)
parents = take ((length split) - 1) split
        = take ((0) - 1) []
        = take (-1) []     # <-- used to return [], now crashes
```